### PR TITLE
harm: cleaner tests

### DIFF
--- a/harm/src/instructions/arith/add.rs
+++ b/harm/src/instructions/arith/add.rs
@@ -63,341 +63,110 @@ define_arith_imm12!(Add, 64, addsub, Reg64, RegOrSp64);
 
 #[cfg(test)]
 mod tests {
+    use harm_test_utils::test_cases;
+
     use super::*;
-    use alloc::vec;
-    use alloc::vec::Vec;
+    use Reg32::*;
+    use Reg64::*;
+    use RegOrSp32::WSP;
+    use RegOrSp64::Reg as RegS;
+    use RegOrSp32::Reg as Reg3S;
+    use RegOrSp64::SP;
+    use RegOrZero32::WZR;
+    use RegOrZero64::Reg as RegZ;
+    use RegOrZero64::XZR;
 
-    #[test]
-    fn test_add_64() {
-        use Reg64::*;
+    const ADD_DB: &str = "
+8b3f2c41	add x1, x2, wzr, uxth #3
+0b0c0041	add w1, w2, w12
+0b2c6c41	add w1, w2, w12, uxtx #3
+0b2c4c41	add w1, w2, w12, uxtw #3
+0b3f6c41	add w1, w2, wzr, uxtx #3
+0b3f4c41	add w1, w2, wzr, uxtw #3
+0b4c1041	add w1, w2, w12, lsr #4
+0b4c13e1	add w1, wzr, w12, lsr #4
+11048c41	add w1, w2, #0x123
+11048fff	add wsp, wsp, #0x123
+11448c41	add w1, w2, #0x123000
+8b0c0041	add x1, x2, x12
+8b2c4c41	add x1, x2, w12, uxtw #3
+8b2c6c41	add x1, x2, x12, uxtx #3
+8b2c4fff	add sp, sp, w12, uxtw #3
+8b2c6fff	add sp, sp, x12, uxtx #3
+8b2c7041	add x1, x2, x12, uxtx #4
+8b3f4c41	add x1, x2, wzr, uxtw #3
+8b3f4fff	add sp, sp, wzr, uxtw #3
+8b4c1041	add x1, x2, x12, lsr #4
+8b4c13e1	add x1, xzr, x12, lsr #4
+91000441	add x1, x2, #1
+910007ff	add sp, sp, #1
+91400441	add x1, x2, #0x1000
+914007ff	add sp, sp, #0x1000
+";
 
-        let codes: Vec<_> = add(X1, X2, X12).unwrap().represent().collect();
-
-        assert_eq!(codes.len(), 1);
-        assert_eq!(codes[0].0, [0x41, 0x00, 0x0c, 0x8b]); // 0x8b0c0041
-    }
-
-    #[test]
-    fn test_add_64_shift() {
-        use Reg64::*;
-
-        let codes: Vec<_> = add(X1, X2, X12)
-            .unwrap()
-            .shift(ShiftMode::LSR, 4)
-            .represent()
-            .collect();
-
-        assert_eq!(codes.len(), 1);
-        assert_eq!(codes[0].0, [0x41, 0x10, 0x4c, 0x8b]); // 0x8b4c1041
-    }
-
-    #[test]
-    fn test_add_64_zero() {
-        use Reg64::*;
-        use RegOrZero64::*;
-
-        let codes: Vec<_> = add(
-            X1.into(),
-            XZR,
-            ShiftedReg::from(X12).shift(ShiftMode::LSR, 4),
-        )
-        .unwrap()
-        .represent()
-        .collect();
-
-        assert_eq!(codes.len(), 1);
-        assert_eq!(codes[0].0, [0xe1, 0x13, 0x4c, 0x8b]); // 0x8b4c13e1
-    }
-
-    #[test]
-    fn test_add_64_extend_uxtx() {
-        use Reg64::*;
-        use RegOrSp64::Reg as RegS;
-        use RegOrZero64::Reg as RegZ;
-
-        let codes: Vec<_> = add(RegS(X1), RegS(X2), RegZ(X12))
-            .unwrap()
-            .extend(ExtendMode::UXTX, 3)
-            .represent()
-            .collect();
-
-        assert_eq!(codes.len(), 1);
-        // add x1, x2, x12, uxtx #3
-        assert_eq!(codes[0].0, [0x41, 0x6c, 0x2c, 0x8b]); // 0x8b2c6c41
-    }
-
-    #[test]
-    fn test_add_64_extend_uxtw() {
-        use Reg64::*;
-
-        let codes: Vec<_> = add(X1, X2, X12)
-            .unwrap()
-            .extend(ExtendMode::UXTW, 3)
-            .represent()
-            .collect();
-
-        assert_eq!(codes.len(), 1);
-        // add x1, x2, w12, uxtw #3
-        assert_eq!(codes[0].0, [0x41, 0x4c, 0x2c, 0x8b]); // 0x8b2c4c41
-    }
-
-    #[test]
-    fn test_add_64_extend_uxth_xzr() {
-        use Reg64::*;
-        use RegOrSp64::Reg as RegS;
-        use RegOrZero64::XZR;
-
-        let codes: Vec<_> = add(RegS(X1), RegS(X2), XZR)
-            .unwrap()
-            .extend(ExtendMode::UXTH, 3)
-            .represent()
-            .collect();
-
-        assert_eq!(codes.len(), 1);
-        // add x1, x2, wzr, uxtw #3
-        assert_eq!(codes[0].0, [0x41, 0x2c, 0x3f, 0x8b]); // 0x8b3f2c41
-    }
-
-    #[test]
-    fn test_add_64_const_1() {
-        use Reg64::*;
-
-        let codes: Vec<_> = add(X1, X2, 1).unwrap().represent().collect();
-
-        assert_eq!(codes.len(), 1);
-        assert_eq!(codes[0].0, [0x41, 0x04, 0x00, 0x91]); // 0x91000441
-    }
-
-    #[test]
-    fn test_add_64_const_0x1000() {
-        use Reg64::*;
-
-        let codes: Vec<_> = add(X1, X2, 0x1000).unwrap().represent().collect();
-
-        assert_eq!(codes.len(), 1);
-        assert_eq!(codes[0].0, [0x41, 0x04, 0x40, 0x91]); // 0x91400441
+    test_cases! {
+        ADD_DB, untested_add_db;
+        test_add_64, add(X1, X2, X12).unwrap(), "add x1, x2, x12";
+        test_add_64_shift, add(X1, X2, X12).unwrap().shift(ShiftMode::LSR, 4), "add x1, x2, x12, lsr #4";
+        test_add_64_zero,
+            add(X1.into(), XZR, ShiftedReg::from(X12).shift(ShiftMode::LSR, 4)).unwrap(),
+            "add x1, xzr, x12, lsr #4";
+        test_add_64_extend_uxtx, add(RegS(X1), RegS(X2), RegZ(X12)).unwrap().extend(ExtendMode::UXTX, 3),
+            "add x1, x2, x12, uxtx #3";
+        // KLUDGE: Using Reg64 instead of Reg32 at the last argument.
+        // To be reimplemented akin `ldr` family.
+        test_add_64_extend_uxtw, add(X1, X2, X12).unwrap().extend(ExtendMode::UXTW, 3), "add x1, x2, w12, uxtw #3";
+        test_add_64_wzr_extend_uxtw, add(RegS(X1), RegS(X2), XZR).unwrap().extend(ExtendMode::UXTW, 3), "add x1, x2, wzr, uxtw #3";
+        test_add_64_extend_uxtx_4, add(X1, X2, X12).unwrap().extend(ExtendMode::UXTX, 4), "add x1, x2, x12, uxtx #4";
+        test_add_64_extend_uxth_xzr,
+            add(RegS(X1), RegS(X2), XZR)
+                .unwrap()
+                .extend(ExtendMode::UXTH, 3),
+            "add x1, x2, wzr, uxth #3";
+        test_add_64_const_1, add(X1, X2, 1).unwrap(), "add x1, x2, #1";
+        test_add_64_const_0x1000, add(X1, X2, 0x1000).unwrap(), "add x1, x2, #0x1000";
+        test_add_sp_64_const_1, add(SP, SP, 1).unwrap(), "add sp, sp, #1";
+        test_add_sp_64_const_0x1000, add(SP, SP, 0x1000).unwrap(), "add sp, sp, #0x1000";
+        test_add_32, add(W1, W2, W12).unwrap(), "add w1, w2, w12";
+        test_add_32_shift, add(W1, W2, W12).unwrap().shift(ShiftMode::LSR, 4), "add w1, w2, w12, lsr #4";
+        test_add_32_zero,
+            add(W1.into(), WZR, ShiftedReg::from(W12).shift(ShiftMode::LSR, 4)).unwrap(),
+            "add w1, wzr, w12, lsr #4";
+        test_add_32_extend_uxtx, add(W1, W2, W12).unwrap().extend(ExtendMode::UXTX, 3), "add w1, w2, w12, uxtx #3";
+        test_add_32_extend_uxtw, add(W1, W2, W12).unwrap().extend(ExtendMode::UXTW, 3), "add w1, w2, w12, uxtw #3";
+        test_add_32_extend_uxtx_wzr,
+            add(Reg3S(W1), Reg3S(W2), WZR)
+                .unwrap()
+                .extend(ExtendMode::UXTX, 3),
+            "add w1, w2, wzr, uxtx #3";
+        test_add_32_extend_uxtw_wzr,
+            add(Reg3S(W1), Reg3S(W2), WZR)
+                .unwrap()
+                .extend(ExtendMode::UXTW, 3),
+            "add w1, w2, wzr, uxtw #3";
+        test_add_32_const_0x123, add(W1, W2, 0x123).unwrap(), "add w1, w2, #0x123";
+        test_add_wsp_32_const_0x123, add(WSP, WSP, 0x123).unwrap(), "add wsp, wsp, #0x123";
+        test_add_32_const_0x123000, add(W1, W2, 0x123000).unwrap(), "add w1, w2, #0x123000";
+        test_add_64_sp_extend_uxtx,
+            add(SP, SP, X12).unwrap().extend(ExtendMode::UXTX, 3),
+            "add sp, sp, x12, uxtx #3";
+        test_add_64_sp_extend_uxtw,
+            add(SP, SP, X12).unwrap().extend(ExtendMode::UXTW, 3),
+            "add sp, sp, w12, uxtw #3";
+        test_add_64_sp_extend_uxtw_xzr,
+            add(SP, SP, XZR).unwrap().extend(ExtendMode::UXTW, 3),
+            "add sp, sp, wzr, uxtw #3";
     }
 
     #[test]
     fn test_add_64_const_0x1001() {
-        use Reg64::*;
-
         let a = add(X1, X2, 0x1001);
         assert!(a.is_err());
     }
 
     #[test]
-    fn test_add_sp_64_const_1() {
-        use RegOrSp64::SP;
-
-        let codes: Vec<_> = add(SP, SP, 1).unwrap().represent().collect();
-
-        assert_eq!(codes.len(), 1);
-        assert_eq!(codes[0].0, [0xFF, 0x07, 0x00, 0x91]); // 0x910007FF
-    }
-
-    #[test]
-    fn test_add_sp_64_const_0x1000() {
-        use RegOrSp64::SP;
-
-        let codes: Vec<_> = add(SP, SP, 1).unwrap().represent().collect();
-
-        assert_eq!(codes.len(), 1);
-        assert_eq!(codes[0].0, [0xFF, 0x07, 0x00, 0x91]); // 0x910007FF
-    }
-
-    #[test]
-    fn test_add_32() {
-        use Reg32::*;
-
-        let codes: Vec<_> = add(W1, W2, W12).unwrap().represent().collect();
-
-        assert_eq!(codes.len(), 1);
-        assert_eq!(codes[0].0, [0x41, 0x00, 0x0c, 0x0b]); // 0x0b0c0041
-    }
-
-    #[test]
-    fn test_add_32_shift() {
-        use Reg32::*;
-
-        let codes: Vec<_> = add(W1, W2, W12)
-            .unwrap()
-            .shift(ShiftMode::LSR, 4)
-            .represent()
-            .collect();
-
-        assert_eq!(codes.len(), 1);
-        assert_eq!(codes[0].0, [0x41, 0x10, 0x4c, 0x0b]); // 0x0b4c1041
-    }
-
-    #[test]
-    fn test_add_32_zero() {
-        use Reg32::*;
-        use RegOrZero32::*;
-
-        let codes: Vec<_> = add(
-            W1.into(),
-            WZR,
-            ShiftedReg::from(W12).shift(ShiftMode::LSR, 4),
-        )
-        .unwrap()
-        .represent()
-        .collect();
-
-        assert_eq!(codes.len(), 1);
-        assert_eq!(codes[0].0, [0xe1, 0x13, 0x4c, 0x0b]); // 0x0b4c13e1
-    }
-
-    #[test]
-    fn test_add_32_extend_uxtx() {
-        use Reg32::*;
-
-        let codes: Vec<_> = add(W1, W2, W12)
-            .unwrap()
-            .extend(ExtendMode::UXTX, 3)
-            .represent()
-            .collect();
-
-        assert_eq!(codes.len(), 1);
-        // add x1, x2, x12, uxtx #3
-        assert_eq!(codes[0].0, [0x41, 0x6c, 0x2c, 0x0b]); // 0x0b2c6c41
-    }
-
-    #[test]
-    fn test_add_32_extend_uxtw() {
-        use Reg32::*;
-
-        let codes: Vec<_> = add(W1, W2, W12)
-            .unwrap()
-            .extend(ExtendMode::UXTW, 3)
-            .represent()
-            .collect();
-
-        assert_eq!(codes.len(), 1);
-        // add w1, w2, w12, uxtw #3
-        assert_eq!(codes[0].0, [0x41, 0x4c, 0x2c, 0x0b]); // 0x0b2c4c41
-    }
-
-    #[test]
-    fn test_add_32_extend_uxtx_wzr() {
-        use Reg32::*;
-        use RegOrSp32::Reg as RegS;
-        use RegOrZero32::WZR;
-
-        let codes: Vec<_> = add(RegS(W1), RegS(W2), WZR)
-            .unwrap()
-            .extend(ExtendMode::UXTX, 3)
-            .represent()
-            .collect();
-
-        assert_eq!(codes.len(), 1);
-        // add w1, w2, wzr, uxtx #3
-        assert_eq!(codes[0].0, [0x41, 0x6c, 0x3f, 0x0b]); // 0x0b3f6c41
-    }
-
-    #[test]
-    fn test_add_32_extend_uxtw_wzr() {
-        use Reg32::*;
-        use RegOrSp32::Reg as RegS;
-        use RegOrZero32::WZR;
-
-        let codes: Vec<_> = add(RegS(W1), RegS(W2), WZR)
-            .unwrap()
-            .extend(ExtendMode::UXTW, 3)
-            .represent()
-            .collect();
-
-        assert_eq!(codes.len(), 1);
-        // add w1, w2, wzr, uxtw #3
-        assert_eq!(codes[0].0, [0x41, 0x4c, 0x3f, 0x0b]); // 0x0b3f4c41
-    }
-
-    #[test]
-    fn test_add_32_const_0x123() {
-        use Reg32::*;
-
-        let codes: Vec<_> = add(W1, W2, 0x123).unwrap().represent().collect();
-
-        assert_eq!(codes.len(), 1);
-        // add w1, w2, 0x123
-        assert_eq!(codes[0].0, [0x41, 0x8c, 0x04, 0x11]); // 0x11048c41
-    }
-
-    #[test]
-    fn test_add_wsp_32_const_0x123() {
-        use RegOrSp32::WSP;
-
-        let codes: Vec<_> = add(WSP, WSP, 0x123).unwrap().represent().collect();
-
-        assert_eq!(codes.len(), 1);
-        // add w1, w2, 0x123
-        assert_eq!(codes[0].0, [0xFF, 0x8F, 0x04, 0x11]); // 0x11048fff
-    }
-
-    #[test]
-    fn test_add_32_const_0x123000() {
-        use Reg32::*;
-
-        let codes: Vec<_> = add(W1, W2, 0x123000).unwrap().represent().collect();
-
-        assert_eq!(codes.len(), 1);
-        // add w1, w2, 0x123000
-        assert_eq!(codes[0].0, [0x41, 0x8c, 0x44, 0x11]); // 0x11448c41
-    }
-
-    #[test]
     fn test_add_32_const_0x1001() {
-        use Reg32::*;
-
         let a = add(W1, W2, 0x1001);
         assert!(a.is_err());
-    }
-
-    #[test]
-    fn test_add_64_sp_extend_uxtx() {
-        use Reg64::*;
-        use RegOrSp64::SP;
-
-        let codes: Vec<_> = add(SP, SP, X12)
-            .unwrap()
-            .extend(ExtendMode::UXTX, 3)
-            .represent()
-            .collect();
-
-        assert_eq!(codes.len(), 1);
-        // add sp, sp, x12, uxtx 3
-        assert_eq!(codes[0].0, [0xff, 0x6f, 0x2c, 0x8b]); // 0x8b2c6fff
-    }
-
-    #[test]
-    fn test_add_64_sp_extend_uxtw() {
-        use Reg64::*;
-        use RegOrSp64::SP;
-
-        let codes: Vec<_> = add(SP, SP, X12)
-            .unwrap()
-            .extend(ExtendMode::UXTW, 3)
-            .represent()
-            .collect();
-
-        assert_eq!(codes.len(), 1);
-        // add sp, sp, w12, uxtw 3
-        assert_eq!(codes[0].0, [0xff, 0x4f, 0x2c, 0x8b]); // 0x8b2c4fff
-    }
-
-    #[test]
-    fn test_add_64_sp_extend_uxtw_xzr() {
-        use RegOrSp64::SP;
-        use RegOrZero64::XZR;
-
-        let codes: Vec<_> = add(SP, SP, XZR)
-            .unwrap()
-            .extend(ExtendMode::UXTW, 3)
-            .represent()
-            .collect();
-
-        assert_eq!(codes.len(), 1);
-        // add sp, sp, wzr, uxtw 3
-        assert_eq!(codes[0].0, [0xff, 0x4f, 0x3f, 0x8b]); // 0x8b3f4fff
     }
 }

--- a/harm/src/instructions/arith/sub.rs
+++ b/harm/src/instructions/arith/sub.rs
@@ -62,58 +62,109 @@ define_arith_imm12!(Sub, 64, addsub, Reg64, RegOrSp64);
 
 #[cfg(test)]
 mod tests {
+    use harm_test_utils::test_cases;
+
     use super::*;
-    use alloc::vec;
-    use alloc::vec::Vec;
+    use Reg32::*;
+    use Reg64::*;
+    use RegOrSp32::WSP;
+    use RegOrSp64::Reg as RegS;
+    use RegOrSp32::Reg as Reg3S;
+    use RegOrSp64::SP;
+    use RegOrZero32::WZR;
+    use RegOrZero64::Reg as RegZ;
+    use RegOrZero64::XZR;
 
-    #[test]
-    fn test_sub_sp_64_const_0x823() {
-        use RegOrSp64::SP;
+    const SUB_DB: &str = "
+cb3f2c41	sub x1, x2, wzr, uxth #3
+4b0c0041	sub w1, w2, w12
+4b2c6c41	sub w1, w2, w12, uxtx #3
+4b2c4c41	sub w1, w2, w12, uxtw #3
+4b3f6c41	sub w1, w2, wzr, uxtx #3
+4b3f4c41	sub w1, w2, wzr, uxtw #3
+4b4c1041	sub w1, w2, w12, lsr #4
+4b4c13e1	sub w1, wzr, w12, lsr #4
+51048c41	sub w1, w2, #0x123
+51048fff	sub wsp, wsp, #0x123
+51448c41	sub w1, w2, #0x123000
+cb0c0041	sub x1, x2, x12
+cb2c4c41	sub x1, x2, w12, uxtw #3
+cb2c6c41	sub x1, x2, x12, uxtx #3
+cb2c4fff	sub sp, sp, w12, uxtw #3
+cb2c6fff	sub sp, sp, x12, uxtx #3
+cb2c7041	sub x1, x2, x12, uxtx #4
+cb3f4c41	sub x1, x2, wzr, uxtw #3
+cb3f4fff	sub sp, sp, wzr, uxtw #3
+cb4c1041	sub x1, x2, x12, lsr #4
+cb4c13e1	sub x1, xzr, x12, lsr #4
+d1000441	sub x1, x2, #1
+d10007ff	sub sp, sp, #1
+d1400441	sub x1, x2, #0x1000
+d14007ff	sub sp, sp, #0x1000
+";
 
-        let codes: Vec<_> = sub(SP, SP, 0x823).unwrap().represent().collect();
-
-        assert_eq!(codes.len(), 1);
-        // sub sp, sp, 0x123
-        assert_eq!(codes[0].0, [0xff, 0x8f, 0x20, 0xd1]); // 0xd1208fff
+    test_cases! {
+        SUB_DB, untested_sub_db;
+        test_sub_64, sub(X1, X2, X12).unwrap(), "sub x1, x2, x12";
+        test_sub_64_shift, sub(X1, X2, X12).unwrap().shift(ShiftMode::LSR, 4), "sub x1, x2, x12, lsr #4";
+        test_sub_64_zero,
+            sub(X1.into(), XZR, ShiftedReg::from(X12).shift(ShiftMode::LSR, 4)).unwrap(),
+            "sub x1, xzr, x12, lsr #4";
+        test_sub_64_extend_uxtx, sub(RegS(X1), RegS(X2), RegZ(X12)).unwrap().extend(ExtendMode::UXTX, 3),
+            "sub x1, x2, x12, uxtx #3";
+        // KLUDGE: Using Reg64 instead of Reg32 at the last argument.
+        // To be reimplemented akin `ldr` family.
+        test_sub_64_extend_uxtw, sub(X1, X2, X12).unwrap().extend(ExtendMode::UXTW, 3), "sub x1, x2, w12, uxtw #3";
+        test_sub_64_wzr_extend_uxtw, sub(RegS(X1), RegS(X2), XZR).unwrap().extend(ExtendMode::UXTW, 3), "sub x1, x2, wzr, uxtw #3";
+        test_sub_64_extend_uxtx_4, sub(X1, X2, X12).unwrap().extend(ExtendMode::UXTX, 4), "sub x1, x2, x12, uxtx #4";
+        test_sub_64_extend_uxth_xzr,
+            sub(RegS(X1), RegS(X2), XZR)
+                .unwrap()
+                .extend(ExtendMode::UXTH, 3),
+            "sub x1, x2, wzr, uxth #3";
+        test_sub_64_const_1, sub(X1, X2, 1).unwrap(), "sub x1, x2, #1";
+        test_sub_64_const_0x1000, sub(X1, X2, 0x1000).unwrap(), "sub x1, x2, #0x1000";
+        test_sub_sp_64_const_1, sub(SP, SP, 1).unwrap(), "sub sp, sp, #1";
+        test_sub_sp_64_const_0x1000, sub(SP, SP, 0x1000).unwrap(), "sub sp, sp, #0x1000";
+        test_sub_32, sub(W1, W2, W12).unwrap(), "sub w1, w2, w12";
+        test_sub_32_shift, sub(W1, W2, W12).unwrap().shift(ShiftMode::LSR, 4), "sub w1, w2, w12, lsr #4";
+        test_sub_32_zero,
+            sub(W1.into(), WZR, ShiftedReg::from(W12).shift(ShiftMode::LSR, 4)).unwrap(),
+            "sub w1, wzr, w12, lsr #4";
+        test_sub_32_extend_uxtx, sub(W1, W2, W12).unwrap().extend(ExtendMode::UXTX, 3), "sub w1, w2, w12, uxtx #3";
+        test_sub_32_extend_uxtw, sub(W1, W2, W12).unwrap().extend(ExtendMode::UXTW, 3), "sub w1, w2, w12, uxtw #3";
+        test_sub_32_extend_uxtx_wzr,
+            sub(Reg3S(W1), Reg3S(W2), WZR)
+                .unwrap()
+                .extend(ExtendMode::UXTX, 3),
+            "sub w1, w2, wzr, uxtx #3";
+        test_sub_32_extend_uxtw_wzr,
+            sub(Reg3S(W1), Reg3S(W2), WZR)
+                .unwrap()
+                .extend(ExtendMode::UXTW, 3),
+            "sub w1, w2, wzr, uxtw #3";
+        test_sub_32_const_0x123, sub(W1, W2, 0x123).unwrap(), "sub w1, w2, #0x123";
+        test_sub_wsp_32_const_0x123, sub(WSP, WSP, 0x123).unwrap(), "sub wsp, wsp, #0x123";
+        test_sub_32_const_0x123000, sub(W1, W2, 0x123000).unwrap(), "sub w1, w2, #0x123000";
+        test_sub_64_sp_extend_uxtx,
+            sub(SP, SP, X12).unwrap().extend(ExtendMode::UXTX, 3),
+            "sub sp, sp, x12, uxtx #3";
+        test_sub_64_sp_extend_uxtw,
+            sub(SP, SP, X12).unwrap().extend(ExtendMode::UXTW, 3),
+            "sub sp, sp, w12, uxtw #3";
+        test_sub_64_sp_extend_uxtw_xzr,
+            sub(SP, SP, XZR).unwrap().extend(ExtendMode::UXTW, 3),
+            "sub sp, sp, wzr, uxtw #3";
     }
 
     #[test]
-    fn test_sub_32_const_0x823() {
-        use Reg32::*;
-
-        let codes: Vec<_> = sub(W1, W2, 0x823).unwrap().represent().collect();
-
-        assert_eq!(codes.len(), 1);
-        // sub w1, w2, 0x123
-        assert_eq!(codes[0].0, [0x41, 0x8c, 0x20, 0x51]); // 0x51208c41
-    }
-
-    #[test]
-    fn test_sub_sp_32_const_0x823() {
-        use RegOrSp32::WSP;
-
-        let codes: Vec<_> = sub(WSP, WSP, 0x823).unwrap().represent().collect();
-
-        assert_eq!(codes.len(), 1);
-        // sub wsp, wsp, 0x123
-        assert_eq!(codes[0].0, [0xff, 0x8f, 0x20, 0x51]); // 0x51208fff
-    }
-
-    #[test]
-    fn test_sub_32_const_0x823000() {
-        use Reg32::*;
-
-        let codes: Vec<_> = sub(W1, W2, 0x823000).unwrap().represent().collect();
-
-        assert_eq!(codes.len(), 1);
-        // sub w1, w2, #0x123, lsl #12 ; =0x123000
-        assert_eq!(codes[0].0, [0x41, 0x8c, 0x60, 0x51]); // 0x51608c41
+    fn test_sub_64_const_0x1001() {
+        let a = sub(X1, X2, 0x1001);
+        assert!(a.is_err());
     }
 
     #[test]
     fn test_sub_32_const_0x1001() {
-        use Reg32::*;
-
         let a = sub(W1, W2, 0x1001);
         assert!(a.is_err());
     }

--- a/harm/src/instructions/branches.rs
+++ b/harm/src/instructions/branches.rs
@@ -155,7 +155,6 @@ mod tests {
     use super::*;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
-    use alloc::vec;
     use alloc::vec::Vec;
 
     #[test]
@@ -163,7 +162,7 @@ mod tests {
         let offset = SBitValue::new(8).unwrap();
         let it = cbnz(X2, offset);
         let words: Vec<_> = it.represent().collect();
-        assert_eq!(words, vec![InstructionCode([0x42, 0x00, 0x00, 0xb5])]); // 0xb5000042
+        assert_eq!(words, [InstructionCode([0x42, 0x00, 0x00, 0xb5])]); // 0xb5000042
     }
 
     #[test]
@@ -171,7 +170,7 @@ mod tests {
         let offset = SBitValue::new(-8).unwrap();
         let it = cbnz(X2, offset);
         let words: Vec<_> = it.represent().collect();
-        assert_eq!(words, vec![InstructionCode([0xc2, 0xff, 0xff, 0xb5])]); // 0xb5ffffc2
+        assert_eq!(words, [InstructionCode([0xc2, 0xff, 0xff, 0xb5])]); // 0xb5ffffc2
     }
 
     #[test]
@@ -179,7 +178,7 @@ mod tests {
         let offset = SBitValue::new(8).unwrap();
         let it = cbz(X2, offset);
         let words: Vec<_> = it.represent().collect();
-        assert_eq!(words, vec![InstructionCode([0x42, 0x00, 0x00, 0xb4])]); // 0xb4000042
+        assert_eq!(words, [InstructionCode([0x42, 0x00, 0x00, 0xb4])]); // 0xb4000042
     }
 
     #[test]
@@ -187,7 +186,7 @@ mod tests {
         let offset = SBitValue::new(-8).unwrap();
         let it = cbz(X2, offset);
         let words: Vec<_> = it.represent().collect();
-        assert_eq!(words, vec![InstructionCode([0xc2, 0xff, 0xff, 0xb4])]); // 0xb4ffffc2
+        assert_eq!(words, [InstructionCode([0xc2, 0xff, 0xff, 0xb4])]); // 0xb4ffffc2
     }
 
     #[test]
@@ -195,7 +194,7 @@ mod tests {
         let offset = SBitValue::new(8).unwrap();
         let it = cbnz(W2, offset);
         let words: Vec<_> = it.represent().collect();
-        assert_eq!(words, vec![InstructionCode([0x42, 0x00, 0x00, 0x35])]); // 35000042
+        assert_eq!(words, [InstructionCode([0x42, 0x00, 0x00, 0x35])]); // 35000042
     }
 
     #[test]
@@ -203,7 +202,7 @@ mod tests {
         let offset = SBitValue::new(-8).unwrap();
         let it = cbnz(W2, offset);
         let words: Vec<_> = it.represent().collect();
-        assert_eq!(words, vec![InstructionCode([0xc2, 0xff, 0xff, 0x35])]); // 35ffffc2
+        assert_eq!(words, [InstructionCode([0xc2, 0xff, 0xff, 0x35])]); // 35ffffc2
     }
 
     #[test]
@@ -211,7 +210,7 @@ mod tests {
         let offset = SBitValue::new(8).unwrap();
         let it = cbz(W2, offset);
         let words: Vec<_> = it.represent().collect();
-        assert_eq!(words, vec![InstructionCode([0x42, 0x00, 0x00, 0x34])]); // 0x34000042
+        assert_eq!(words, [InstructionCode([0x42, 0x00, 0x00, 0x34])]); // 0x34000042
     }
 
     #[test]
@@ -219,6 +218,6 @@ mod tests {
         let offset = SBitValue::new(-8).unwrap();
         let it = cbz(W2, offset);
         let words: Vec<_> = it.represent().collect();
-        assert_eq!(words, vec![InstructionCode([0xc2, 0xff, 0xff, 0x34])]); // 0x34ffffc2
+        assert_eq!(words, [InstructionCode([0xc2, 0xff, 0xff, 0x34])]); // 0x34ffffc2
     }
 }

--- a/harm/src/instructions/branches/ret.rs
+++ b/harm/src/instructions/branches/ret.rs
@@ -42,20 +42,16 @@ impl Instruction for Ret {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::vec;
-    use alloc::vec::Vec;
+    use harm_test_utils::test_cases;
 
-    #[test]
-    fn test_ret() {
-        let ret_inst = ret();
-        let codes: Vec<InstructionCode> = ret_inst.represent().collect();
-        assert_eq!(codes, vec![InstructionCode::from_u32(0xd65f03c0)]);
-    }
+    const RET_DB: &str = "
+d65f03c0	ret
+d65f0060	ret x3
+";
 
-    #[test]
-    fn test_ret_reg() {
-        let ret_inst = ret().reg(Reg64::X3);
-        let codes: Vec<InstructionCode> = ret_inst.represent().collect();
-        assert_eq!(codes, vec![InstructionCode::from_u32(0xd65f0060)]);
-    }
+    test_cases!(
+        RET_DB, untested_ret_db;
+        test_ret, ret(), "ret";
+        test_ret_reg, ret().reg(Reg64::X3), "ret x3";
+    );
 }

--- a/harm/src/instructions/branches/testbranch.rs
+++ b/harm/src/instructions/branches/testbranch.rs
@@ -111,7 +111,6 @@ mod tests {
     use crate::register::Reg64::*;
     use crate::register::RegOrZero32::WZR;
     use crate::register::RegOrZero64::XZR;
-    use alloc::vec;
     use alloc::vec::Vec;
 
     #[test]
@@ -121,7 +120,7 @@ mod tests {
         let it = tbz(X2, bit, offset);
         let words: Vec<_> = it.represent().collect();
         // tbz x2, 42, 76
-        assert_eq!(words, vec![InstructionCode([0x62, 0x02, 0x50, 0xb6])]); // 0xb6500262
+        assert_eq!(words, [InstructionCode([0x62, 0x02, 0x50, 0xb6])]); // 0xb6500262
     }
 
     #[test]
@@ -131,7 +130,7 @@ mod tests {
         let it = tbz(X2, bit, offset);
         let words: Vec<_> = it.represent().collect();
 
-        assert_eq!(words, vec![InstructionCode([0x62, 0x02, 0xe8, 0x36])]); // 0x36e80262
+        assert_eq!(words, [InstructionCode([0x62, 0x02, 0xe8, 0x36])]); // 0x36e80262
     }
 
     #[test]
@@ -140,7 +139,7 @@ mod tests {
         let bit = UBitValue::new(42).unwrap();
         let it = tbz(XZR, bit, offset);
         let words: Vec<_> = it.represent().collect();
-        assert_eq!(words, vec![InstructionCode([0x7f, 0x02, 0x50, 0xb6])]); // 0xb650027f
+        assert_eq!(words, [InstructionCode([0x7f, 0x02, 0x50, 0xb6])]); // 0xb650027f
     }
 
     #[test]
@@ -149,7 +148,7 @@ mod tests {
         let bit = UBitValue::new(29).unwrap();
         let it = tbz(XZR, bit, offset);
         let words: Vec<_> = it.represent().collect();
-        assert_eq!(words, vec![InstructionCode([0x7f, 0x02, 0xe8, 0x36])]); // 0x36e8027f
+        assert_eq!(words, [InstructionCode([0x7f, 0x02, 0xe8, 0x36])]); // 0x36e8027f
     }
 
     #[test]
@@ -158,7 +157,7 @@ mod tests {
         let bit = UBitValue::new(29).unwrap();
         let it = tbz(W2, bit, offset);
         let words: Vec<_> = it.represent().collect();
-        assert_eq!(words, vec![InstructionCode([0x62, 0x02, 0xe8, 0x36])]); // 0x36e80262
+        assert_eq!(words, [InstructionCode([0x62, 0x02, 0xe8, 0x36])]); // 0x36e80262
     }
 
     #[test]
@@ -167,6 +166,6 @@ mod tests {
         let bit = UBitValue::new(29).unwrap();
         let it = tbz(WZR, bit, offset);
         let words: Vec<_> = it.represent().collect();
-        assert_eq!(words, vec![InstructionCode([0x7f, 0x02, 0xe8, 0x36])]); // 0x36e8027f
+        assert_eq!(words, [InstructionCode([0x7f, 0x02, 0xe8, 0x36])]); // 0x36e8027f
     }
 }

--- a/tools/harm-test-utils/src/lib.rs
+++ b/tools/harm-test-utils/src/lib.rs
@@ -11,7 +11,7 @@ macro_rules! test_cases {
                 let inst: alloc::vec::Vec<_> = $expr.represent().collect();
                 assert_eq!(
                     inst,
-                    alloc::vec![$($crate::db($db_data, $key)),*]
+                    [$($crate::db($db_data, $key)),*]
         );
             }
         )*
@@ -21,7 +21,7 @@ macro_rules! test_cases {
         fn $completeness_test() {
             extern crate alloc;
             let mut db = $crate::Db::new($db_data).unwrap_or_else(|e| panic!("{e}"));
-            let keys = alloc::vec![$($($key,)+)*].into_iter().collect::<alloc::collections::BTreeSet<_>>();
+            let keys = [$($($key,)+)*].into_iter().collect::<alloc::collections::BTreeSet<_>>();
             let db_keys = db.keys().collect::<alloc::collections::BTreeSet<_>>();
             let mut untested_keys = db_keys.difference(&keys).collect::<alloc::vec::Vec<_>>();
             untested_keys.sort_unstable();


### PR DESCRIPTION
1. use `test_cases!` in some older modules;
2. less `alloc` use.