### PR TITLE
harm: redesign `Instruction` trait

### DIFF
--- a/harm/src/instructions/arith/add.rs
+++ b/harm/src/instructions/arith/add.rs
@@ -17,7 +17,7 @@ use aarchmrs_types::InstructionCode;
 
 use super::{Error, Extend, ExtendMode, ExtendedReg, Shift, ShiftMode, ShiftedReg};
 use crate::{
-    instructions::Instruction,
+    instructions::RawInstruction,
     register::{IntoCode as _, Reg32, Reg64, RegOrSp32, RegOrSp64, RegOrZero32, RegOrZero64},
 };
 
@@ -66,6 +66,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use Reg32::*;
     use Reg64::*;
     use RegOrSp32::Reg as Reg3S;

--- a/harm/src/instructions/arith/sub.rs
+++ b/harm/src/instructions/arith/sub.rs
@@ -14,7 +14,7 @@ use aarchmrs_types::InstructionCode;
 use super::Error;
 use crate::{
     instructions::{
-        Instruction,
+        RawInstruction,
         arith::{Extend, ExtendMode, ExtendedReg, Shift, ShiftMode, ShiftedReg},
     },
     register::{IntoCode as _, Reg32, Reg64, RegOrSp32, RegOrSp64, RegOrZero32, RegOrZero64},
@@ -65,6 +65,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use Reg32::*;
     use Reg64::*;
     use RegOrSp32::Reg as Reg3S;

--- a/harm/src/instructions/branches/ret.rs
+++ b/harm/src/instructions/branches/ret.rs
@@ -6,7 +6,7 @@
 use aarchmrs_instructions::A64::control::branch_reg::RET_64R_branch_reg::RET_64R_branch_reg;
 use aarchmrs_types::InstructionCode;
 
-use super::Instruction;
+use super::RawInstruction;
 use crate::register::{IntoCode as _, Reg64, RegOrZero64};
 
 #[inline]
@@ -31,17 +31,19 @@ impl Ret {
     }
 }
 
-impl Instruction for Ret {
-    fn represent(self) -> impl Iterator<Item = InstructionCode> + 'static {
+impl RawInstruction for Ret {
+    #[inline]
+    fn to_code(&self) -> InstructionCode {
         let reg = self.0;
-        let code = RET_64R_branch_reg(reg.code());
-        core::iter::once(code)
+
+        RET_64R_branch_reg(reg.code())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::instructions::InstructionSeq;
     use harm_test_utils::test_cases;
 
     const RET_DB: &str = "

--- a/harm/src/instructions/ldst.rs
+++ b/harm/src/instructions/ldst.rs
@@ -63,12 +63,14 @@ pub type ScaledOffset64 = UBitValue<12, 3>;
 
 pub type UnscaledOffset = SBitValue<9>;
 
+#[derive(Copy, Clone, Debug)]
 pub struct ByteShift;
 
 impl LdStDestShiftOption for ByteShift {
     const SHIFT_SIZE: u32 = 0;
 }
 
+#[derive(Copy, Clone, Debug)]
 pub struct HalfShift;
 
 impl LdStDestShiftOption for HalfShift {

--- a/harm/src/instructions/ldst/increment.rs
+++ b/harm/src/instructions/ldst/increment.rs
@@ -10,6 +10,7 @@ use crate::{
 
 pub type LdStIncOffset = SBitValue<9>;
 
+#[derive(Copy, Clone, Debug)]
 pub struct Inc<Offset> {
     pub offset: Offset,
 }

--- a/harm/src/instructions/ldst/ldr.rs
+++ b/harm/src/instructions/ldst/ldr.rs
@@ -122,7 +122,7 @@ use aarchmrs_instructions::A64::ldst::{
 use super::shift_extend::*;
 use super::{Inc, LdStIncOffset, ScaledOffset32, ScaledOffset64};
 use crate::bits::BitError;
-use crate::instructions::Instruction;
+use crate::instructions::RawInstruction;
 use crate::register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64};
 
 /// A `LDR` instruction with a destination and an address.
@@ -187,6 +187,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
     use crate::{

--- a/harm/src/instructions/ldst/ldrb.rs
+++ b/harm/src/instructions/ldst/ldrb.rs
@@ -77,7 +77,7 @@ use super::shift_extend::*;
 use super::{ByteShift, Inc, LdStIncOffset, ScaledOffset8};
 use crate::{
     bits::BitError,
-    instructions::Instruction,
+    instructions::RawInstruction,
     register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64},
 };
 
@@ -136,6 +136,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
     use crate::{

--- a/harm/src/instructions/ldst/ldrh.rs
+++ b/harm/src/instructions/ldst/ldrh.rs
@@ -79,7 +79,7 @@ use super::{HalfShift, shift_extend::*};
 use super::{Inc, LdStIncOffset, ScaledOffset16};
 use crate::{
     bits::BitError,
-    instructions::Instruction,
+    instructions::RawInstruction,
     register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64},
 };
 
@@ -138,6 +138,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
     use crate::{

--- a/harm/src/instructions/ldst/ldrsb.rs
+++ b/harm/src/instructions/ldst/ldrsb.rs
@@ -90,7 +90,7 @@ use aarchmrs_instructions::A64::ldst::{
 use super::shift_extend::*;
 use super::{ByteShift, Inc, LdStIncOffset, ScaledOffset8};
 use crate::bits::BitError;
-use crate::instructions::Instruction;
+use crate::instructions::RawInstruction;
 use crate::register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64};
 
 /// A `LDRSB` instruction with a destination and an address.
@@ -149,6 +149,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
     use crate::{

--- a/harm/src/instructions/ldst/ldrsh.rs
+++ b/harm/src/instructions/ldst/ldrsh.rs
@@ -90,7 +90,7 @@ use aarchmrs_instructions::A64::ldst::{
 use super::shift_extend::*;
 use super::{HalfShift, Inc, LdStIncOffset, ScaledOffset16};
 use crate::bits::BitError;
-use crate::instructions::Instruction;
+use crate::instructions::RawInstruction;
 use crate::register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64};
 
 /// A `LDRSH` instruction with a destination and an address.
@@ -149,6 +149,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
     use crate::{

--- a/harm/src/instructions/ldst/ldrsw.rs
+++ b/harm/src/instructions/ldst/ldrsw.rs
@@ -116,7 +116,7 @@ use aarchmrs_instructions::A64::ldst::{
 use super::shift_extend::*;
 use super::{Inc, LdStIncOffset, ScaledOffset32};
 use crate::bits::BitError;
-use crate::instructions::Instruction;
+use crate::instructions::RawInstruction;
 use crate::register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64};
 
 /// A `LDRSW` instruction with a destination and an address.
@@ -178,6 +178,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
     use crate::{

--- a/harm/src/instructions/ldst/ldur.rs
+++ b/harm/src/instructions/ldst/ldur.rs
@@ -8,7 +8,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::{
 };
 
 use crate::bits::BitError;
-use crate::instructions::Instruction;
+use crate::instructions::RawInstruction;
 use crate::register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64};
 
 use super::UnscaledOffset;
@@ -56,6 +56,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
     use RegOrSp64::SP;

--- a/harm/src/instructions/ldst/ldurb.rs
+++ b/harm/src/instructions/ldst/ldurb.rs
@@ -6,7 +6,7 @@
 use aarchmrs_instructions::A64::ldst::ldst_unscaled::LDURB_32_ldst_unscaled::LDURB_32_ldst_unscaled;
 
 use crate::bits::BitError;
-use crate::instructions::Instruction;
+use crate::instructions::RawInstruction;
 use crate::register::{IntoCode, RegOrSp64, RegOrZero32};
 
 use super::UnscaledOffset;
@@ -53,6 +53,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
     use RegOrSp64::SP;

--- a/harm/src/instructions/ldst/ldurh.rs
+++ b/harm/src/instructions/ldst/ldurh.rs
@@ -6,7 +6,7 @@
 use aarchmrs_instructions::A64::ldst::ldst_unscaled::LDURH_32_ldst_unscaled::LDURH_32_ldst_unscaled;
 
 use crate::bits::BitError;
-use crate::instructions::Instruction;
+use crate::instructions::RawInstruction;
 use crate::register::{IntoCode, RegOrSp64, RegOrZero32};
 
 use super::UnscaledOffset;
@@ -53,6 +53,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
     use RegOrSp64::SP;

--- a/harm/src/instructions/ldst/ldursb.rs
+++ b/harm/src/instructions/ldst/ldursb.rs
@@ -9,7 +9,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::{
 };
 
 use crate::bits::BitError;
-use crate::instructions::Instruction;
+use crate::instructions::RawInstruction;
 use crate::register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64};
 
 use super::UnscaledOffset;
@@ -57,6 +57,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
     use RegOrSp64::SP;

--- a/harm/src/instructions/ldst/ldursh.rs
+++ b/harm/src/instructions/ldst/ldursh.rs
@@ -9,7 +9,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::{
 };
 
 use crate::bits::BitError;
-use crate::instructions::Instruction;
+use crate::instructions::RawInstruction;
 use crate::register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64};
 
 use super::UnscaledOffset;
@@ -57,6 +57,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
     use RegOrSp64::SP;

--- a/harm/src/instructions/ldst/ldursw.rs
+++ b/harm/src/instructions/ldst/ldursw.rs
@@ -6,7 +6,7 @@
 use aarchmrs_instructions::A64::ldst::ldst_unscaled::LDURSW_64_ldst_unscaled::LDURSW_64_ldst_unscaled;
 
 use crate::bits::BitError;
-use crate::instructions::Instruction;
+use crate::instructions::RawInstruction;
 use crate::register::{IntoCode, RegOrSp64, RegOrZero64};
 
 use super::UnscaledOffset;
@@ -53,6 +53,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg64::*;
     use RegOrSp64::SP;
     use RegOrZero64::XZR;

--- a/harm/src/instructions/ldst/macros.rs
+++ b/harm/src/instructions/ldst/macros.rs
@@ -101,48 +101,45 @@ macro_rules! define_reg_offset_rules {
         }
 
         ::paste::paste! {
-            impl Instruction for $name<$rt, (RegOrSp64, Extended<$shift, RegOrZero64>)> {
+            impl RawInstruction for $name<$rt, (RegOrSp64, Extended<$shift, RegOrZero64>)> {
                 #[inline]
-                fn represent(self) -> impl Iterator<Item = crate::InstructionCode> + 'static {
+                fn to_code(&self) -> crate::InstructionCode {
                     let (base, offset) = self.addr;
-                    let code = [<$mnem:upper _ $bitness _ldst_regoff>](
+                    [<$mnem:upper _ $bitness _ldst_regoff>](
                         offset.offset.code(),
                         (offset.extend as u8).into(),
                         offset.shifted.into(),
                         base.code(),
                         self.rt.code(),
-                    );
-                    core::iter::once(code)
+                    )
                 }
             }
 
-            impl Instruction for $name<$rt, (RegOrSp64, Extended<$shift, RegOrZero32>)> {
+            impl RawInstruction for $name<$rt, (RegOrSp64, Extended<$shift, RegOrZero32>)> {
                 #[inline]
-                fn represent(self) -> impl Iterator<Item = crate::InstructionCode> + 'static {
+                fn to_code(&self) -> crate::InstructionCode {
                     let (base, offset) = self.addr;
-                    let code = [<$mnem:upper _ $bitness _ldst_regoff>](
+                    [<$mnem:upper _ $bitness _ldst_regoff>](
                         offset.offset.code(),
                         (offset.extend as u8).into(),
                         offset.shifted.into(),
                         base.code(),
                         self.rt.code(),
-                    );
-                    core::iter::once(code)
+                    )
                 }
             }
 
-            impl Instruction for $name<$rt, (RegOrSp64, RegOrZero64)> {
+            impl RawInstruction for $name<$rt, (RegOrSp64, RegOrZero64)> {
                 #[inline]
-                fn represent(self) -> impl Iterator<Item = crate::InstructionCode> + 'static {
+                fn to_code(&self) -> crate::InstructionCode {
                     let (base, offset) = self.addr;
-                    let code = [<$mnem:upper _ $bitness _ldst_regoff>](
+                    [<$mnem:upper _ $bitness _ldst_regoff>](
                         offset.code(),
                         (LdStExtendOption64::default() as u8).into(),
                         0b0.into(),
                         base.code(),
                         self.rt.code(),
-                    );
-                    core::iter::once(code)
+                    )
                 }
             }
         }
@@ -234,31 +231,31 @@ macro_rules! define_imm_offset_rules {
         }
 
         ::paste::paste! {
-            impl $crate::instructions::Instruction for $name<$rt, (RegOrSp64, $offset_type)> {
+            impl $crate::instructions::RawInstruction for $name<$rt, (RegOrSp64, $offset_type)> {
                 #[inline]
-                fn represent(self) -> impl ::core::iter::Iterator<Item = $crate::InstructionCode> + 'static {
+                fn to_code(&self) -> crate::InstructionCode {
                     let (base, offset) = self.addr;
                     let code = [<$mnem:upper _ $bitness _ldst_pos>](offset.into(), base.code(), self.rt.code());
-                    ::core::iter::once(code)
+                    code
                 }
             }
 
-            impl $crate::instructions::Instruction for $name<$rt, (Inc<LdStIncOffset>, RegOrSp64)> {
+            impl $crate::instructions::RawInstruction for $name<$rt, (Inc<LdStIncOffset>, RegOrSp64)> {
                 #[inline]
-                fn represent(self) -> impl ::core::iter::Iterator<Item = $crate::InstructionCode> + 'static {
+                fn to_code(&self) -> crate::InstructionCode {
                     let (inc, base) = self.addr;
                     let code = [<$mnem:upper _ $bitness _ldst_immpre>](inc.offset.into(), base.code(), self.rt.code());
-                    ::core::iter::once(code)
+                    code
                 }
             }
 
-            impl $crate::instructions::Instruction for $name<$rt, (RegOrSp64, Inc<LdStIncOffset>)> {
+            impl $crate::instructions::RawInstruction for $name<$rt, (RegOrSp64, Inc<LdStIncOffset>)> {
                 #[inline]
-                fn represent(self) -> impl ::core::iter::Iterator<Item = $crate::InstructionCode> + 'static {
+                fn to_code(&self) -> crate::InstructionCode {
                     let (base, inc) = self.addr;
 
                     let code = [<$mnem:upper _ $bitness _ldst_immpost>](inc.offset.into(), base.code(), self.rt.code());
-                    ::core::iter::once(code)
+                    code
                 }
             }
         }
@@ -300,12 +297,11 @@ macro_rules! define_unscaled_imm_offset_rules {
         }
 
         ::paste::paste! {
-            impl Instruction for $name<$rt, (RegOrSp64, UnscaledOffset)> {
+            impl RawInstruction for $name<$rt, (RegOrSp64, UnscaledOffset)> {
                 #[inline]
-                fn represent(self) -> impl Iterator<Item = crate::InstructionCode> + 'static {
+                fn to_code(&self) -> crate::InstructionCode {
                     let (base, offset) = self.addr;
-                    let code = [<$mnem:upper _ $bitness _ldst_unscaled>](offset.into(), base.code(), self.rt.code());
-                    ::core::iter::once(code)
+                    [<$mnem:upper _ $bitness _ldst_unscaled>](offset.into(), base.code(), self.rt.code())
                 }
             }
         }
@@ -353,12 +349,12 @@ macro_rules! define_pc_offset_rules {
         }
 
         ::paste::paste! {
-            impl $crate::instructions::Instruction for $name<$rt, ($crate::instructions::ldst::Pc, $crate::instructions::ldst::LdStPcOffset)> {
+            impl $crate::instructions::RawInstruction for $name<$rt, ($crate::instructions::ldst::Pc, $crate::instructions::ldst::LdStPcOffset)> {
                 #[inline]
-                fn represent(self) -> impl ::core::iter::Iterator<Item = $crate::InstructionCode> + 'static {
+                fn to_code(&self) -> crate::InstructionCode {
                     let (_pc, offset) = self.addr;
                     let code = [<$mnem:upper _ $bitness _ loadlit>](offset.into(), self.rt.code());
-                    ::core::iter::once(code)
+                    code
                 }
             }
         }

--- a/harm/src/instructions/ldst/str.rs
+++ b/harm/src/instructions/ldst/str.rs
@@ -122,7 +122,7 @@ use super::shift_extend::*;
 use super::{Inc, LdStIncOffset, ScaledOffset32, ScaledOffset64};
 use crate::{
     bits::BitError,
-    instructions::Instruction,
+    instructions::RawInstruction,
     register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64},
 };
 
@@ -182,6 +182,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
     use crate::{

--- a/harm/src/instructions/ldst/strb.rs
+++ b/harm/src/instructions/ldst/strb.rs
@@ -77,7 +77,7 @@ use super::shift_extend::*;
 use super::{ByteShift, Inc, LdStIncOffset, ScaledOffset8};
 use crate::{
     bits::BitError,
-    instructions::Instruction,
+    instructions::RawInstruction,
     register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64},
 };
 
@@ -136,6 +136,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
     use crate::{

--- a/harm/src/instructions/ldst/strh.rs
+++ b/harm/src/instructions/ldst/strh.rs
@@ -79,7 +79,7 @@ use super::{HalfShift, shift_extend::*};
 use super::{Inc, LdStIncOffset, ScaledOffset16};
 use crate::{
     bits::BitError,
-    instructions::Instruction,
+    instructions::RawInstruction,
     register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64},
 };
 
@@ -138,6 +138,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
     use crate::{

--- a/harm/src/instructions/ldst/stur.rs
+++ b/harm/src/instructions/ldst/stur.rs
@@ -8,7 +8,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::{
 };
 
 use crate::bits::BitError;
-use crate::instructions::Instruction;
+use crate::instructions::RawInstruction;
 use crate::register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64};
 
 use super::UnscaledOffset;
@@ -56,6 +56,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
     use RegOrSp64::SP;

--- a/harm/src/instructions/ldst/sturb.rs
+++ b/harm/src/instructions/ldst/sturb.rs
@@ -6,7 +6,7 @@
 use aarchmrs_instructions::A64::ldst::ldst_unscaled::STURB_32_ldst_unscaled::STURB_32_ldst_unscaled;
 
 use crate::bits::BitError;
-use crate::instructions::Instruction;
+use crate::instructions::RawInstruction;
 use crate::register::{IntoCode, RegOrSp64, RegOrZero32};
 
 use super::UnscaledOffset;
@@ -53,6 +53,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
     use RegOrSp64::SP;

--- a/harm/src/instructions/ldst/sturh.rs
+++ b/harm/src/instructions/ldst/sturh.rs
@@ -6,7 +6,7 @@
 use aarchmrs_instructions::A64::ldst::ldst_unscaled::STURH_32_ldst_unscaled::STURH_32_ldst_unscaled;
 
 use crate::bits::BitError;
-use crate::instructions::Instruction;
+use crate::instructions::RawInstruction;
 use crate::register::{IntoCode, RegOrSp64, RegOrZero32};
 
 use super::UnscaledOffset;
@@ -53,6 +53,7 @@ mod tests {
     use harm_test_utils::test_cases;
 
     use super::*;
+    use crate::instructions::InstructionSeq;
     use crate::register::Reg32::*;
     use crate::register::Reg64::*;
     use RegOrSp64::SP;

--- a/harm/src/lib.rs
+++ b/harm/src/lib.rs
@@ -8,5 +8,6 @@ extern crate alloc;
 pub mod bits;
 pub mod instructions;
 pub mod register;
+pub mod reloc;
 
 pub use aarchmrs_types::InstructionCode;

--- a/harm/src/reloc.rs
+++ b/harm/src/reloc.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Reloc {
+    // This is a stub type which is intentionally a zero-variant enum.
+    // Currently it is used as Option<Reloc> which is always None.
+}

--- a/tools/harm-test-utils/src/lib.rs
+++ b/tools/harm-test-utils/src/lib.rs
@@ -8,10 +8,10 @@ macro_rules! test_cases {
             #[test]
             fn $test_name() {
                 extern crate alloc;
-                let inst: alloc::vec::Vec<_> = $expr.represent().collect();
+                let inst: alloc::vec::Vec<_> = $expr.encode().collect();
                 assert_eq!(
                     inst,
-                    [$($crate::db($db_data, $key)),*]
+                    [$(($crate::db($db_data, $key), None)),*]
         );
             }
         )*
@@ -33,5 +33,15 @@ macro_rules! test_cases {
         }
 
         test_cases!($db_data; $($test_name, $expr, $($key),+;)*);
+    }
+}
+
+#[macro_export]
+macro_rules! inst {
+    ($([$b0:expr, $b1:expr, $b2:expr, $b3:expr]),*) => {
+        [$((InstructionCode([$b0, $b1, $b2, $b3]), None)),*]
+    };
+    ($($code:literal),*) => {
+        [$((InstructionCode::from_u32($code), None)),*]
     }
 }


### PR DESCRIPTION
Use three new traits:

1. `RawInstruction` for raw instructions, i.e. single opcodes without relocation.
2. `RelocatableInstruction` for instructions with relocations.
3. `InstructionSeq` for a sequence of relocatable instructions (for certain virtual instructions or user macros).

This commit also introduces `Reloc` type which is a zero-variant enum yet.