### PR TITLE
harm: implement `TryFrom` for UBitValue/SBitValue

### DIFF
--- a/harm/src/bits.rs
+++ b/harm/src/bits.rs
@@ -78,6 +78,28 @@ impl<const SIGNIFICANT_BITS: u32, const ALIGN: u32> UBitValue<SIGNIFICANT_BITS, 
     }
 }
 
+impl<const SIGNIFICANT_BITS: u32, const ALIGN: u32> TryFrom<u32>
+    for UBitValue<SIGNIFICANT_BITS, ALIGN>
+{
+    type Error = BitError;
+
+    #[inline]
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl<const SIGNIFICANT_BITS: u32, const ALIGN: u32> TryFrom<i32>
+    for UBitValue<SIGNIFICANT_BITS, ALIGN>
+{
+    type Error = BitError;
+
+    #[inline]
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        Self::new_i32(value)
+    }
+}
+
 impl From<bool> for UBitValue<1> {
     fn from(value: bool) -> Self {
         Self(value as u32)
@@ -89,6 +111,28 @@ impl<const SIGNIFICANT_BITS: u32, const ALIGN: u32> From<UBitValue<SIGNIFICANT_B
 {
     fn from(value: UBitValue<SIGNIFICANT_BITS, ALIGN>) -> Self {
         Self(value.0)
+    }
+}
+
+impl<const SIGNIFICANT_BITS: u32, const ALIGN: u32> TryFrom<u32>
+    for SBitValue<SIGNIFICANT_BITS, ALIGN>
+{
+    type Error = BitError;
+
+    #[inline]
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        Self::new_u32(value)
+    }
+}
+
+impl<const SIGNIFICANT_BITS: u32, const ALIGN: u32> TryFrom<i32>
+    for SBitValue<SIGNIFICANT_BITS, ALIGN>
+{
+    type Error = BitError;
+
+    #[inline]
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        Self::new(value)
     }
 }
 

--- a/harm/src/instructions/branches.rs
+++ b/harm/src/instructions/branches.rs
@@ -82,7 +82,7 @@ impl MakeBranch<i32> for Branch<BranchOffset> {
     type Output = Result<Self, BitError>;
 
     fn make(offset: i32) -> Self::Output {
-        SBitValue::new(offset).map(Self)
+        BranchOffset::try_from(offset).map(Self)
     }
 }
 
@@ -129,7 +129,7 @@ impl MakeBranchCond<i32> for Branch<(BranchCond, BranchCondOffset)> {
     type Output = Result<Self, BitError>;
 
     fn make(cond: BranchCond, offset: i32) -> Self::Output {
-        SBitValue::new(offset).map(|offset| Self((cond, offset)))
+        BranchCondOffset::try_from(offset).map(|offset| Self((cond, offset)))
     }
 }
 

--- a/harm/src/instructions/ldst/macros.rs
+++ b/harm/src/instructions/ldst/macros.rs
@@ -177,7 +177,7 @@ macro_rules! define_imm_offset_rules {
 
             #[inline]
             fn new(rt: Rt, (base, offset): (B, u32)) -> Self::Output {
-                let offset = <$offset_type>::new(offset)?;
+                let offset = <$offset_type>::try_from(offset)?;
                 Ok(Self {
                     rt: rt.into(),
                     addr: (base.into(), offset),
@@ -196,7 +196,7 @@ macro_rules! define_imm_offset_rules {
 
             #[inline]
             fn new(rt: Rt, (base, offset): (B, i32)) -> Self::Output {
-                let offset = <$offset_type>::new_i32(offset)?;
+                let offset = <$offset_type>::try_from(offset)?;
                 Ok(Self {
                     rt: rt.into(),
                     addr: (base.into(), offset),
@@ -289,7 +289,7 @@ macro_rules! define_unscaled_imm_offset_rules {
             type Output = Result<Self, BitError>;
 
             fn new(rt: Rt, (base, offset): (Base, i32)) -> Self::Output {
-                UnscaledOffset::new(offset).map(|offset| Self {
+                UnscaledOffset::try_from(offset).map(|offset| Self {
                     rt: rt.into(),
                     addr: (base.into(), offset),
                 })
@@ -341,7 +341,7 @@ macro_rules! define_pc_offset_rules {
 
             #[inline]
             fn new(rt: Rt, (pc, offset): ($crate::instructions::ldst::Pc, i32)) -> Self::Output {
-                $crate::instructions::ldst::LdStPcOffset::new(offset).map(|offset| Self {
+                $crate::instructions::ldst::LdStPcOffset::try_from(offset).map(|offset| Self {
                     rt: rt.into(),
                     addr: (pc, offset)
                 })


### PR DESCRIPTION
Construct from `u32`/`i32`, calling respective constructors.