### PR TITLE
harm: fix/implement simple load/store forms

### DIFF
--- a/harm/src/instructions/ldst/ldp.rs
+++ b/harm/src/instructions/ldst/ldp.rs
@@ -80,6 +80,7 @@ a9408c41	ldp x1, x3, [x2, 8]
 a95f8c41	ldp x1, x3, [x2, 504]
 a9700c41	ldp x1, x3, [x2, -256]
 a9400c41	ldp x1, x3, [x2, 0]
+a9400c41	ldp x1, x3, [x2]
 a97f8fe1	ldp x1, x3, [sp, -8]
 a9408fe1	ldp x1, x3, [sp, 8]
 a95f8fe1	ldp x1, x3, [sp, 504]
@@ -147,6 +148,7 @@ a9e003e1	ldp x1, x0, [sp, #-0x200]!
         test_ldp_x1_x2_504, ldp(X1, X3, (X2, 504i32)).unwrap(), "ldp x1, x3, [x2, 504]";
         test_ldp_x1_x2_m256, ldp(X1, X3, (X2, -256i32)).unwrap(), "ldp x1, x3, [x2, -256]";
         test_ldp_x1_x2_0, ldp(X1, X3, (X2, 0i32)).unwrap(), "ldp x1, x3, [x2, 0]";
+        test_ldp_x1_x2_simple, ldp(X1, X3, (X2,)), "ldp x1, x3, [x2]";
         test_ldp_x1_sp_m8, ldp(X1, X3, (SP, -8i32)).unwrap(), "ldp x1, x3, [sp, -8]";
         test_ldp_x1_sp_8, ldp(X1, X3, (SP, 8i32)).unwrap(), "ldp x1, x3, [sp, 8]";
         test_ldp_x1_sp_504, ldp(X1, X3, (SP, 504i32)).unwrap(), "ldp x1, x3, [sp, 504]";

--- a/harm/src/instructions/ldst/ldpsw.rs
+++ b/harm/src/instructions/ldst/ldpsw.rs
@@ -68,6 +68,7 @@ mod tests {
 695f8c41	ldpsw x1, x3, [x2, 252]
 69600c41	ldpsw x1, x3, [x2, -256]
 69400c41	ldpsw x1, x3, [x2, 0]
+69400c41	ldpsw x1, x3, [x2]
 697f0fe1	ldpsw x1, x3, [sp, -8]
 69410fe1	ldpsw x1, x3, [sp, 8]
 695f8fe1	ldpsw x1, x3, [sp, 252]
@@ -83,7 +84,6 @@ mod tests {
 695f8fff	ldpsw xzr, x3, [sp, 252]
 69600fff	ldpsw xzr, x3, [sp, -256]
 69400fff	ldpsw xzr, x3, [sp, 0]
-
 ";
 
     const LDPSW_PRE_POST_INC_DB: &str = "
@@ -97,7 +97,6 @@ mod tests {
 68e003e1	ldpsw x1, x0, [sp], #-0x100
 69e00041	ldpsw x1, x0, [x2, #-0x100]!
 69e003e1	ldpsw x1, x0, [sp, #-0x100]!
-
 ";
 
     test_cases! {
@@ -107,6 +106,7 @@ mod tests {
         test_ldpsw_x1_x2_252, ldpsw(X1, X3, (X2, 252i32)).unwrap(), "ldpsw x1, x3, [x2, 252]";
         test_ldpsw_x1_x2_m256, ldpsw(X1, X3, (X2, -256i32)).unwrap(), "ldpsw x1, x3, [x2, -256]";
         test_ldpsw_x1_x2_0, ldpsw(X1, X3, (X2, 0i32)).unwrap(), "ldpsw x1, x3, [x2, 0]";
+        test_ldpsw_x1_x2_simple, ldpsw(X1, X3, (X2,)), "ldpsw x1, x3, [x2]";
         test_ldpsw_x1_sp_m8, ldpsw(X1, X3, (SP, -8i32)).unwrap(), "ldpsw x1, x3, [sp, -8]";
         test_ldpsw_x1_sp_8, ldpsw(X1, X3, (SP, 8i32)).unwrap(), "ldpsw x1, x3, [sp, 8]";
         test_ldpsw_x1_sp_252, ldpsw(X1, X3, (SP, 252i32)).unwrap(), "ldpsw x1, x3, [sp, 252]";

--- a/harm/src/instructions/ldst/ldr.rs
+++ b/harm/src/instructions/ldst/ldr.rs
@@ -157,6 +157,20 @@ define_reg_offset_rules!(Load, MakeLoad, LDR, RegOrZero32, 32);
 //
 // ## LDR (immediate offset)
 //
+define_simple_rules!(
+    Load,
+    MakeLoad,
+    RegOrZero64,
+    ScaledOffset64,
+    ScaledOffset64::default()
+);
+define_simple_rules!(
+    Load,
+    MakeLoad,
+    RegOrZero32,
+    ScaledOffset32,
+    ScaledOffset32::default()
+);
 define_imm_offset_rules!(Load, MakeLoad, LDR, RegOrZero64, 64, ScaledOffset64);
 define_imm_offset_rules!(Load, MakeLoad, LDR, RegOrZero32, 32, ScaledOffset32);
 
@@ -250,6 +264,7 @@ b94193e2	ldr w2, [sp, #0x190]
 f940c902	ldr x2, [x8, #0x190]
 f940cbe2	ldr x2, [sp, #0x190]
 f940cbff	ldr xzr, [sp, #0x190]
+f9400102	ldr x2, [x8]
 ";
 
     // NB: not a real syntax.
@@ -338,6 +353,7 @@ f85d6fe1	ldr x1, [sp, #-0x2a]!
         test_ldr_r64_sp_scaled_imm3, ldr(X2, (SP, 0x190i32)).unwrap(), "ldr x2, [sp, #0x190]";
         test_ldr_wzr_r64_scaled_imm3, ldr(WZR, (X8, 0x190i32)).unwrap(), "ldr wzr, [x8, #0x190]";
         test_ldr_xzr_sp_scaled_imm3, ldr(XZR, (SP, 0x190i32)).unwrap(), "ldr xzr, [sp, #0x190]";
+        test_ldr_r64_r64_simple, ldr(X2, (X8,)), "ldr x2, [x8]";
     }
 
     test_cases! {

--- a/harm/src/instructions/ldst/ldr.rs
+++ b/harm/src/instructions/ldst/ldr.rs
@@ -157,20 +157,6 @@ define_reg_offset_rules!(Load, MakeLoad, LDR, RegOrZero32, 32);
 //
 // ## LDR (immediate offset)
 //
-define_simple_rules!(
-    Load,
-    MakeLoad,
-    RegOrZero64,
-    ScaledOffset64,
-    ScaledOffset64::default()
-);
-define_simple_rules!(
-    Load,
-    MakeLoad,
-    RegOrZero32,
-    ScaledOffset32,
-    ScaledOffset32::default()
-);
 define_imm_offset_rules!(Load, MakeLoad, LDR, RegOrZero64, 64, ScaledOffset64);
 define_imm_offset_rules!(Load, MakeLoad, LDR, RegOrZero32, 32, ScaledOffset32);
 

--- a/harm/src/instructions/ldst/ldrb.rs
+++ b/harm/src/instructions/ldst/ldrb.rs
@@ -113,7 +113,13 @@ define_reg_offset_rules!(Ldrb, MakeLdrb, LDRB, RegOrZero32, "32B", ByteShift);
 //
 // ## LDRB (immediate offset)
 //
-define_simple_rules!(Ldrb, MakeLdrb, RegOrZero32, ScaledOffset8, ScaledOffset8::default());
+define_simple_rules!(
+    Ldrb,
+    MakeLdrb,
+    RegOrZero32,
+    ScaledOffset8,
+    ScaledOffset8::default()
+);
 define_imm_offset_rules!(Ldrb, MakeLdrb, LDRB, RegOrZero32, "32", ScaledOffset8);
 
 //

--- a/harm/src/instructions/ldst/ldrb.rs
+++ b/harm/src/instructions/ldst/ldrb.rs
@@ -113,6 +113,7 @@ define_reg_offset_rules!(Ldrb, MakeLdrb, LDRB, RegOrZero32, "32B", ByteShift);
 //
 // ## LDRB (immediate offset)
 //
+define_simple_rules!(Ldrb, MakeLdrb, RegOrZero32, ScaledOffset8, ScaledOffset8::default());
 define_imm_offset_rules!(Ldrb, MakeLdrb, LDRB, RegOrZero32, "32", ScaledOffset8);
 
 //
@@ -161,6 +162,7 @@ mod tests {
 3863f902	ldrb w2, [x8, x3, sxtx #0]
 387f6902	ldrb w2, [x8, xzr]
 387f6be2	ldrb w2, [sp, xzr]
+
 ";
 
     // 'ldrb (w2|x2), [(x8|sp), #0x190]'
@@ -168,6 +170,7 @@ mod tests {
 39464102	ldrb w2, [x8, #0x190]
 3946411f	ldrb wzr, [x8, #0x190]
 394643e2	ldrb w2, [sp, #0x190]
+39400102	ldrb w2, [x8]
 ";
 
     const LDRB_PRE_POST_INC_DB: &str = "
@@ -206,6 +209,7 @@ mod tests {
         test_ldrb_wzr_r64_scaled_imm2, ldrb(WZR, (X8, 0x190u32)).unwrap(), "ldrb wzr, [x8, #0x190]";
         test_ldrb_r32_r64_scaled_imm3, ldrb(W2, (X8, 0x190i32)).unwrap(), "ldrb w2, [x8, #0x190]";
         test_ldrb_wzr_r64_scaled_imm3, ldrb(WZR, (X8, 0x190i32)).unwrap(), "ldrb wzr, [x8, #0x190]";
+        test_ldrb_r32_r64_simple, ldrb(W2, (X8,)), "ldrb w2, [x8]";
     }
 
     test_cases! {

--- a/harm/src/instructions/ldst/ldrb.rs
+++ b/harm/src/instructions/ldst/ldrb.rs
@@ -113,13 +113,6 @@ define_reg_offset_rules!(Ldrb, MakeLdrb, LDRB, RegOrZero32, "32B", ByteShift);
 //
 // ## LDRB (immediate offset)
 //
-define_simple_rules!(
-    Ldrb,
-    MakeLdrb,
-    RegOrZero32,
-    ScaledOffset8,
-    ScaledOffset8::default()
-);
 define_imm_offset_rules!(Ldrb, MakeLdrb, LDRB, RegOrZero32, "32", ScaledOffset8);
 
 //

--- a/harm/src/instructions/ldst/ldrh.rs
+++ b/harm/src/instructions/ldst/ldrh.rs
@@ -115,7 +115,13 @@ define_reg_offset_rules!(Ldrh, MakeLdrh, LDRH, RegOrZero32, "32", HalfShift);
 //
 // ## LDRH (immediate offset)
 //
-define_simple_rules!(Ldrh, MakeLdrh, RegOrZero32, ScaledOffset16, ScaledOffset16::default());
+define_simple_rules!(
+    Ldrh,
+    MakeLdrh,
+    RegOrZero32,
+    ScaledOffset16,
+    ScaledOffset16::default()
+);
 define_imm_offset_rules!(Ldrh, MakeLdrh, LDRH, RegOrZero32, "32", ScaledOffset16);
 
 //

--- a/harm/src/instructions/ldst/ldrh.rs
+++ b/harm/src/instructions/ldst/ldrh.rs
@@ -115,13 +115,6 @@ define_reg_offset_rules!(Ldrh, MakeLdrh, LDRH, RegOrZero32, "32", HalfShift);
 //
 // ## LDRH (immediate offset)
 //
-define_simple_rules!(
-    Ldrh,
-    MakeLdrh,
-    RegOrZero32,
-    ScaledOffset16,
-    ScaledOffset16::default()
-);
 define_imm_offset_rules!(Ldrh, MakeLdrh, LDRH, RegOrZero32, "32", ScaledOffset16);
 
 //

--- a/harm/src/instructions/ldst/ldrh.rs
+++ b/harm/src/instructions/ldst/ldrh.rs
@@ -115,6 +115,7 @@ define_reg_offset_rules!(Ldrh, MakeLdrh, LDRH, RegOrZero32, "32", HalfShift);
 //
 // ## LDRH (immediate offset)
 //
+define_simple_rules!(Ldrh, MakeLdrh, RegOrZero32, ScaledOffset16, ScaledOffset16::default());
 define_imm_offset_rules!(Ldrh, MakeLdrh, LDRH, RegOrZero32, "32", ScaledOffset16);
 
 //
@@ -173,6 +174,7 @@ mod tests {
 79432102	ldrh w2, [x8, #0x190]
 7943211f	ldrh wzr, [x8, #0x190]
 794323e2	ldrh w2, [sp, #0x190]
+79400102	ldrh w2, [x8]
 ";
 
     const LDRH_PRE_POST_INC_DB: &str = "
@@ -215,6 +217,7 @@ mod tests {
         test_ldrh_wzr_r64_scaled_imm2, ldrh(WZR, (X8, 0x190u32)).unwrap(), "ldrh wzr, [x8, #0x190]";
         test_ldrh_r32_r64_scaled_imm3, ldrh(W2, (X8, 0x190i32)).unwrap(), "ldrh w2, [x8, #0x190]";
         test_ldrh_wzr_r64_scaled_imm3, ldrh(WZR, (X8, 0x190i32)).unwrap(), "ldrh wzr, [x8, #0x190]";
+        test_ldrh_r32_r64_simple, ldrh(W2, (X8,)), "ldrh w2, [x8]";
     }
 
     test_cases! {

--- a/harm/src/instructions/ldst/ldrsb.rs
+++ b/harm/src/instructions/ldst/ldrsb.rs
@@ -125,6 +125,20 @@ define_reg_offset_rules!(Ldrsb, MakeLdrsb, LDRSB, RegOrZero32, "32B", ByteShift)
 //
 // ## LDRSB (immediate offset)
 //
+define_simple_rules!(
+    Ldrsb,
+    MakeLdrsb,
+    RegOrZero64,
+    ScaledOffset8,
+    ScaledOffset8::default()
+);
+define_simple_rules!(
+    Ldrsb,
+    MakeLdrsb,
+    RegOrZero32,
+    ScaledOffset8,
+    ScaledOffset8::default()
+);
 define_imm_offset_rules!(Ldrsb, MakeLdrsb, LDRSB, RegOrZero64, 64, ScaledOffset8);
 define_imm_offset_rules!(Ldrsb, MakeLdrsb, LDRSB, RegOrZero32, 32, ScaledOffset8);
 
@@ -202,6 +216,7 @@ mod tests {
 39864102	ldrsb x2, [x8, #0x190]
 398643e2	ldrsb x2, [sp, #0x190]
 398643ff	ldrsb xzr, [sp, #0x190]
+39800102	ldrsb x2, [x8]
 ";
 
     const LDRSB_PRE_POST_INC_DB: &str = "
@@ -274,6 +289,7 @@ mod tests {
         test_ldrsb_r64_sp_scaled_imm3, ldrsb(X2, (SP, 0x190i32)).unwrap(), "ldrsb x2, [sp, #0x190]";
         test_ldrsb_wzr_r64_scaled_imm3, ldrsb(WZR, (X8, 0x190i32)).unwrap(), "ldrsb wzr, [x8, #0x190]";
         test_ldrsb_xzr_sp_scaled_imm3, ldrsb(XZR, (SP, 0x190i32)).unwrap(), "ldrsb xzr, [sp, #0x190]";
+        test_ldrsb_r64_r64_simple, ldrsb(X2, (X8,)), "ldrsb x2, [x8]";
     }
 
     test_cases! {

--- a/harm/src/instructions/ldst/ldrsb.rs
+++ b/harm/src/instructions/ldst/ldrsb.rs
@@ -125,20 +125,6 @@ define_reg_offset_rules!(Ldrsb, MakeLdrsb, LDRSB, RegOrZero32, "32B", ByteShift)
 //
 // ## LDRSB (immediate offset)
 //
-define_simple_rules!(
-    Ldrsb,
-    MakeLdrsb,
-    RegOrZero64,
-    ScaledOffset8,
-    ScaledOffset8::default()
-);
-define_simple_rules!(
-    Ldrsb,
-    MakeLdrsb,
-    RegOrZero32,
-    ScaledOffset8,
-    ScaledOffset8::default()
-);
 define_imm_offset_rules!(Ldrsb, MakeLdrsb, LDRSB, RegOrZero64, 64, ScaledOffset8);
 define_imm_offset_rules!(Ldrsb, MakeLdrsb, LDRSB, RegOrZero32, 32, ScaledOffset8);
 

--- a/harm/src/instructions/ldst/ldrsh.rs
+++ b/harm/src/instructions/ldst/ldrsh.rs
@@ -125,20 +125,6 @@ define_reg_offset_rules!(Ldrsh, MakeLdrsh, LDRSH, RegOrZero32, 32, HalfShift);
 //
 // ## LDRSH (immediate offset)
 //
-define_simple_rules!(
-    Ldrsh,
-    MakeLdrsh,
-    RegOrZero32,
-    ScaledOffset16,
-    ScaledOffset16::default()
-);
-define_simple_rules!(
-    Ldrsh,
-    MakeLdrsh,
-    RegOrZero64,
-    ScaledOffset16,
-    ScaledOffset16::default()
-);
 define_imm_offset_rules!(Ldrsh, MakeLdrsh, LDRSH, RegOrZero64, 64, ScaledOffset16);
 define_imm_offset_rules!(Ldrsh, MakeLdrsh, LDRSH, RegOrZero32, 32, ScaledOffset16);
 

--- a/harm/src/instructions/ldst/ldrsh.rs
+++ b/harm/src/instructions/ldst/ldrsh.rs
@@ -125,6 +125,20 @@ define_reg_offset_rules!(Ldrsh, MakeLdrsh, LDRSH, RegOrZero32, 32, HalfShift);
 //
 // ## LDRSH (immediate offset)
 //
+define_simple_rules!(
+    Ldrsh,
+    MakeLdrsh,
+    RegOrZero32,
+    ScaledOffset16,
+    ScaledOffset16::default()
+);
+define_simple_rules!(
+    Ldrsh,
+    MakeLdrsh,
+    RegOrZero64,
+    ScaledOffset16,
+    ScaledOffset16::default()
+);
 define_imm_offset_rules!(Ldrsh, MakeLdrsh, LDRSH, RegOrZero64, 64, ScaledOffset16);
 define_imm_offset_rules!(Ldrsh, MakeLdrsh, LDRSH, RegOrZero32, 32, ScaledOffset16);
 
@@ -202,6 +216,7 @@ mod tests {
 79832102	ldrsh x2, [x8, #0x190]
 798323e2	ldrsh x2, [sp, #0x190]
 798323ff	ldrsh xzr, [sp, #0x190]
+79800102	ldrsh x2, [x8]
 ";
 
     const LDRSH_PRE_POST_INC_DB: &str = "
@@ -274,6 +289,7 @@ mod tests {
         test_ldrsh_r64_sp_scaled_imm3, ldrsh(X2, (SP, 0x190i32)).unwrap(), "ldrsh x2, [sp, #0x190]";
         test_ldrsh_wzr_r64_scaled_imm3, ldrsh(WZR, (X8, 0x190i32)).unwrap(), "ldrsh wzr, [x8, #0x190]";
         test_ldrsh_xzr_sp_scaled_imm3, ldrsh(XZR, (SP, 0x190i32)).unwrap(), "ldrsh xzr, [sp, #0x190]";
+        test_ldrsh_r64_r64_simple, ldrsh(X2, (X8,)), "ldrsh x2, [x8]";
     }
 
     test_cases! {

--- a/harm/src/instructions/ldst/ldrsw.rs
+++ b/harm/src/instructions/ldst/ldrsw.rs
@@ -150,6 +150,13 @@ define_reg_offset_rules!(Ldrsw, MakeLdrsw, LDRSW, RegOrZero64, 64, RegOrZero32);
 //
 // ## LDRSW (immediate offset)
 //
+define_simple_rules!(
+    Ldrsw,
+    MakeLdrsw,
+    RegOrZero64,
+    ScaledOffset32,
+    ScaledOffset32::default()
+);
 define_imm_offset_rules!(Ldrsw, MakeLdrsw, LDRSW, RegOrZero64, 64, ScaledOffset32);
 
 //
@@ -222,6 +229,7 @@ b8bfe902	ldrsw x2, [x8, xzr, sxtx]
 b9819102	ldrsw x2, [x8, #0x190]
 b98193e2	ldrsw x2, [sp, #0x190]
 b98193ff	ldrsw xzr, [sp, #0x190]
+b9800102	ldrsw x2, [x8]
 ";
 
     // NB: not a real syntax.
@@ -277,6 +285,7 @@ b89d6fe1	ldrsw x1, [sp, #-0x2a]!
         test_ldrsw_xzr_sp_scaled_imm2, ldrsw(XZR, (SP, 0x190u32)).unwrap(), "ldrsw xzr, [sp, #0x190]";
         test_ldrsw_r64_sp_scaled_imm3, ldrsw(X2, (SP, 0x190i32)).unwrap(), "ldrsw x2, [sp, #0x190]";
         test_ldrsw_xzr_sp_scaled_imm3, ldrsw(XZR, (SP, 0x190i32)).unwrap(), "ldrsw xzr, [sp, #0x190]";
+        test_ldrsw_r64_r64_simple, ldrsw(X2, (X8,)), "ldrsw x2, [x8]";
     }
 
     test_cases! {

--- a/harm/src/instructions/ldst/ldrsw.rs
+++ b/harm/src/instructions/ldst/ldrsw.rs
@@ -150,13 +150,6 @@ define_reg_offset_rules!(Ldrsw, MakeLdrsw, LDRSW, RegOrZero64, 64, RegOrZero32);
 //
 // ## LDRSW (immediate offset)
 //
-define_simple_rules!(
-    Ldrsw,
-    MakeLdrsw,
-    RegOrZero64,
-    ScaledOffset32,
-    ScaledOffset32::default()
-);
 define_imm_offset_rules!(Ldrsw, MakeLdrsw, LDRSW, RegOrZero64, 64, ScaledOffset32);
 
 //

--- a/harm/src/instructions/ldst/ldur.rs
+++ b/harm/src/instructions/ldst/ldur.rs
@@ -70,6 +70,7 @@ f8401041	ldur x1, [x2, 1]
 f84ff041	ldur x1, [x2, 255]
 f8500041	ldur x1, [x2, -256]
 f8400041	ldur x1, [x2, 0]
+f8400041	ldur x1, [x2]
 f85ff3e1	ldur x1, [sp, -1]
 f84013e1	ldur x1, [sp, 1]
 f84ff3e1	ldur x1, [sp, 255]
@@ -114,6 +115,7 @@ b84003ff	ldur wzr, [sp, 0]
         test_ldur_x1_x2_255, ldur(X1, (X2, 255)).unwrap(), "ldur x1, [x2, 255]";
         test_ldur_x1_x2_m256, ldur(X1, (X2, -256)).unwrap(), "ldur x1, [x2, -256]";
         test_ldur_x1_x2_0, ldur(X1, (X2, 0)).unwrap(), "ldur x1, [x2, 0]";
+        test_ldur_x1_x2_simple, ldur(X1, (X2,)), "ldur x1, [x2]";
         test_ldur_x1_sp_m1, ldur(X1, (SP, -1)).unwrap(), "ldur x1, [sp, -1]";
         test_ldur_x1_sp_1, ldur(X1, (SP, 1)).unwrap(), "ldur x1, [sp, 1]";
         test_ldur_x1_sp_255, ldur(X1, (SP, 255)).unwrap(), "ldur x1, [sp, 255]";

--- a/harm/src/instructions/ldst/ldurb.rs
+++ b/harm/src/instructions/ldst/ldurb.rs
@@ -65,6 +65,7 @@ mod tests {
 384ff041	ldurb w1, [x2, 255]
 38500041	ldurb w1, [x2, -256]
 38400041	ldurb w1, [x2, 0]
+38400041	ldurb w1, [x2]
 385ff3e1	ldurb w1, [sp, -1]
 384013e1	ldurb w1, [sp, 1]
 384ff3e1	ldurb w1, [sp, 255]
@@ -89,6 +90,7 @@ mod tests {
         test_ldurb_w1_x2_255, ldurb(W1, (X2, 255)).unwrap(), "ldurb w1, [x2, 255]";
         test_ldurb_w1_x2_m256, ldurb(W1, (X2, -256)).unwrap(), "ldurb w1, [x2, -256]";
         test_ldurb_w1_x2_0, ldurb(W1, (X2, 0)).unwrap(), "ldurb w1, [x2, 0]";
+        test_ldurb_w1_x2_simple, ldurb(W1, (X2,)), "ldurb w1, [x2]";
         test_ldurb_w1_sp_m1, ldurb(W1, (SP, -1)).unwrap(), "ldurb w1, [sp, -1]";
         test_ldurb_w1_sp_1, ldurb(W1, (SP, 1)).unwrap(), "ldurb w1, [sp, 1]";
         test_ldurb_w1_sp_255, ldurb(W1, (SP, 255)).unwrap(), "ldurb w1, [sp, 255]";

--- a/harm/src/instructions/ldst/ldurh.rs
+++ b/harm/src/instructions/ldst/ldurh.rs
@@ -65,6 +65,7 @@ mod tests {
 784ff041	ldurh w1, [x2, 255]
 78500041	ldurh w1, [x2, -256]
 78400041	ldurh w1, [x2, 0]
+78400041	ldurh w1, [x2]
 785ff3e1	ldurh w1, [sp, -1]
 784013e1	ldurh w1, [sp, 1]
 784ff3e1	ldurh w1, [sp, 255]
@@ -89,6 +90,7 @@ mod tests {
         test_ldurh_w1_x2_255, ldurh(W1, (X2, 255)).unwrap(), "ldurh w1, [x2, 255]";
         test_ldurh_w1_x2_m256, ldurh(W1, (X2, -256)).unwrap(), "ldurh w1, [x2, -256]";
         test_ldurh_w1_x2_0, ldurh(W1, (X2, 0)).unwrap(), "ldurh w1, [x2, 0]";
+        test_ldurh_w1_x2_simple, ldurh(W1, (X2,)), "ldurh w1, [x2]";
         test_ldurh_w1_sp_m1, ldurh(W1, (SP, -1)).unwrap(), "ldurh w1, [sp, -1]";
         test_ldurh_w1_sp_1, ldurh(W1, (SP, 1)).unwrap(), "ldurh w1, [sp, 1]";
         test_ldurh_w1_sp_255, ldurh(W1, (SP, 255)).unwrap(), "ldurh w1, [sp, 255]";

--- a/harm/src/instructions/ldst/ldursb.rs
+++ b/harm/src/instructions/ldst/ldursb.rs
@@ -71,6 +71,7 @@ mod tests {
 388ff041	ldursb x1, [x2, 255]
 38900041	ldursb x1, [x2, -256]
 38800041	ldursb x1, [x2, 0]
+38800041	ldursb x1, [x2]
 389ff3e1	ldursb x1, [sp, -1]
 388013e1	ldursb x1, [sp, 1]
 388ff3e1	ldursb x1, [sp, 255]
@@ -115,6 +116,7 @@ mod tests {
         test_ldursb_x1_x2_255, ldursb(X1, (X2, 255)).unwrap(), "ldursb x1, [x2, 255]";
         test_ldursb_x1_x2_m256, ldursb(X1, (X2, -256)).unwrap(), "ldursb x1, [x2, -256]";
         test_ldursb_x1_x2_0, ldursb(X1, (X2, 0)).unwrap(), "ldursb x1, [x2, 0]";
+        test_ldursb_x1_x2_simple, ldursb(X1, (X2,)), "ldursb x1, [x2]";
         test_ldursb_x1_sp_m1, ldursb(X1, (SP, -1)).unwrap(), "ldursb x1, [sp, -1]";
         test_ldursb_x1_sp_1, ldursb(X1, (SP, 1)).unwrap(), "ldursb x1, [sp, 1]";
         test_ldursb_x1_sp_255, ldursb(X1, (SP, 255)).unwrap(), "ldursb x1, [sp, 255]";

--- a/harm/src/instructions/ldst/ldursh.rs
+++ b/harm/src/instructions/ldst/ldursh.rs
@@ -71,6 +71,7 @@ mod tests {
 788ff041	ldursh x1, [x2, 255]
 78900041	ldursh x1, [x2, -256]
 78800041	ldursh x1, [x2, 0]
+78800041	ldursh x1, [x2]
 789ff3e1	ldursh x1, [sp, -1]
 788013e1	ldursh x1, [sp, 1]
 788ff3e1	ldursh x1, [sp, 255]
@@ -115,6 +116,7 @@ mod tests {
         test_ldursh_x1_x2_255, ldursh(X1, (X2, 255)).unwrap(), "ldursh x1, [x2, 255]";
         test_ldursh_x1_x2_m256, ldursh(X1, (X2, -256)).unwrap(), "ldursh x1, [x2, -256]";
         test_ldursh_x1_x2_0, ldursh(X1, (X2, 0)).unwrap(), "ldursh x1, [x2, 0]";
+        test_ldursh_x1_x2_simple, ldursh(X1, (X2,)), "ldursh x1, [x2]";
         test_ldursh_x1_sp_m1, ldursh(X1, (SP, -1)).unwrap(), "ldursh x1, [sp, -1]";
         test_ldursh_x1_sp_1, ldursh(X1, (SP, 1)).unwrap(), "ldursh x1, [sp, 1]";
         test_ldursh_x1_sp_255, ldursh(X1, (SP, 255)).unwrap(), "ldursh x1, [sp, 255]";

--- a/harm/src/instructions/ldst/ldursw.rs
+++ b/harm/src/instructions/ldst/ldursw.rs
@@ -65,6 +65,7 @@ b8801041	ldursw x1, [x2, 1]
 b88ff041	ldursw x1, [x2, 255]
 b8900041	ldursw x1, [x2, -256]
 b8800041	ldursw x1, [x2, 0]
+b8800041	ldursw x1, [x2]
 b89ff3e1	ldursw x1, [sp, -1]
 b88013e1	ldursw x1, [sp, 1]
 b88ff3e1	ldursw x1, [sp, 255]
@@ -89,6 +90,7 @@ b88003ff	ldursw xzr, [sp, 0]
         test_ldursw_x1_x2_255, ldursw(X1, (X2, 255)).unwrap(), "ldursw x1, [x2, 255]";
         test_ldursw_x1_x2_m256, ldursw(X1, (X2, -256)).unwrap(), "ldursw x1, [x2, -256]";
         test_ldursw_x1_x2_0, ldursw(X1, (X2, 0)).unwrap(), "ldursw x1, [x2, 0]";
+        test_ldursw_x1_x2_simple, ldursw(X1, (X2,)), "ldursw x1, [x2]";
         test_ldursw_x1_sp_m1, ldursw(X1, (SP, -1)).unwrap(), "ldursw x1, [sp, -1]";
         test_ldursw_x1_sp_1, ldursw(X1, (SP, 1)).unwrap(), "ldursw x1, [sp, 1]";
         test_ldursw_x1_sp_255, ldursw(X1, (SP, 255)).unwrap(), "ldursw x1, [sp, 255]";

--- a/harm/src/instructions/ldst/macros.rs
+++ b/harm/src/instructions/ldst/macros.rs
@@ -279,6 +279,22 @@ macro_rules! define_unscaled_imm_offset_rules {
             }
         }
 
+        impl<Rt, Base> $make_name<Rt, Base>
+            for $name<$rt, (RegOrSp64, UnscaledOffset)>
+        where
+            Rt: Into<$rt>,
+            Base: Into<RegOrSp64>,
+        {
+            type Output = Self;
+
+            fn new(rt: Rt, base: Base) -> Self::Output {
+                Self {
+                    rt: rt.into(),
+                    addr: (base.into(), UnscaledOffset::default()),
+                }
+            }
+        }
+
         impl<Rt, Base> $make_name<Rt, (Base,)>
             for $name<$rt, (RegOrSp64, UnscaledOffset)>
         where
@@ -457,6 +473,24 @@ macro_rules! define_pair_imm_offset_rules {
                 Self {
                     rt: (rt.0.into(), rt.1.into()),
                     addr: (base.into(), offset),
+                }
+            }
+        }
+
+        #[doc = r" `LDP` with 64-bit destination and base register."]
+        impl<Rt1, Rt2, B> $trait_name<Rt1, Rt2, B>
+            for $name<$rt, (RegOrSp64, $offset_type)>
+        where
+            Rt1: Into<$rt>,
+            Rt2: Into<$rt>,
+            B: Into<RegOrSp64>,
+        {
+            type Output = Self;
+            #[inline]
+            fn new(rt: (Rt1, Rt2), base: B) -> Self {
+                Self {
+                    rt: (rt.0.into(), rt.1.into()),
+                    addr: (base.into(), <$offset_type>::default()),
                 }
             }
         }

--- a/harm/src/instructions/ldst/macros.rs
+++ b/harm/src/instructions/ldst/macros.rs
@@ -111,8 +111,8 @@ macro_rules! define_reg_offset_rules {
     };
 }
 
-macro_rules! define_simple_rules {
-    ($name:ident, $trait_name:ident, $rt:ty, $offset_type:ty, $default_offset:expr) => {
+macro_rules! define_imm_offset_rules {
+    ($name:ident, $trait_name:ident, $mnem:ident, $rt:ty, $bitness:expr, $offset_type:ty) => {
         /// `LDR` with 64-bit destination, bare base register.
         impl<Rt, Base> $trait_name<Rt, Base> for $name<$rt, (RegOrSp64, $offset_type)>
         where
@@ -125,8 +125,7 @@ macro_rules! define_simple_rules {
             fn new(rt: Rt, base: Base) -> Self {
                 Self {
                     rt: rt.into(),
-                    // TODO does the spec says something specific?
-                    addr: (base.into(), $default_offset),
+                    addr: (base.into(), <$offset_type>::default()),
                 }
             }
         }
@@ -143,15 +142,11 @@ macro_rules! define_simple_rules {
             fn new(rt: Rt, (base,): (Base,)) -> Self {
                 Self {
                     rt: rt.into(),
-                    addr: (base.into(), $default_offset),
+                    addr: (base.into(), <$offset_type>::default()),
                 }
             }
         }
-    };
-}
 
-macro_rules! define_imm_offset_rules {
-    ($name:ident, $trait_name:ident, $mnem:ident, $rt:ty, $bitness:expr, $offset_type:ty) => {
         /// `LDR` with 64-bit destination, base register with aligned immediate offset.
         impl<Rt, B> $trait_name<Rt, (B, $offset_type)>
             for $name<$rt, (RegOrSp64, $offset_type)>

--- a/harm/src/instructions/ldst/macros.rs
+++ b/harm/src/instructions/ldst/macros.rs
@@ -147,7 +147,7 @@ macro_rules! define_simple_rules {
                 }
             }
         }
-    }
+    };
 }
 
 macro_rules! define_imm_offset_rules {

--- a/harm/src/instructions/ldst/macros.rs
+++ b/harm/src/instructions/ldst/macros.rs
@@ -46,41 +46,6 @@ macro_rules! define_reg_offset_rules {
             }
         }
 
-        /// `LDR` with 64-bit destination, bare base register.
-        impl<Rt, Base> $trait_name<Rt, Base> for $name<$rt, (RegOrSp64, RegOrZero64)>
-        where
-            Rt: Into<$rt>,
-            Base: Into<RegOrSp64>,
-        {
-            type Output = Self;
-
-            #[inline]
-            fn new(rt: Rt, base: Base) -> Self {
-                Self {
-                    rt: rt.into(),
-                    // TODO does the spec says something specific?
-                    addr: (base.into(), RegOrZero64::XZR),
-                }
-            }
-        }
-
-        /// `LDR` with 64-bit destination, bare base register as a tuple.
-        impl<Rt, Base> $trait_name<Rt, (Base,)> for $name<$rt, (RegOrSp64, RegOrZero64)>
-        where
-            Rt: Into<$rt>,
-            Base: Into<RegOrSp64>,
-        {
-            type Output = Self;
-
-            #[inline]
-            fn new(rt: Rt, (base,): (Base,)) -> Self {
-                Self {
-                    rt: rt.into(),
-                    addr: (base.into(), RegOrZero64::XZR),
-                }
-            }
-        }
-
         /// `LDR` with 64-bit destination, base register with 64-bit offset without scaling.
         impl<Rt, Base, OffsetReg> $trait_name<Rt, (Base, OffsetReg)>
             for $name<$rt, (RegOrSp64, RegOrZero64)>
@@ -144,6 +109,45 @@ macro_rules! define_reg_offset_rules {
             }
         }
     };
+}
+
+macro_rules! define_simple_rules {
+    ($name:ident, $trait_name:ident, $rt:ty, $offset_type:ty, $default_offset:expr) => {
+        /// `LDR` with 64-bit destination, bare base register.
+        impl<Rt, Base> $trait_name<Rt, Base> for $name<$rt, (RegOrSp64, $offset_type)>
+        where
+            Rt: Into<$rt>,
+            Base: Into<RegOrSp64>,
+        {
+            type Output = Self;
+
+            #[inline]
+            fn new(rt: Rt, base: Base) -> Self {
+                Self {
+                    rt: rt.into(),
+                    // TODO does the spec says something specific?
+                    addr: (base.into(), $default_offset),
+                }
+            }
+        }
+
+        /// `LDR` with 64-bit destination, bare base register as a tuple.
+        impl<Rt, Base> $trait_name<Rt, (Base,)> for $name<$rt, (RegOrSp64, $offset_type)>
+        where
+            Rt: Into<$rt>,
+            Base: Into<RegOrSp64>,
+        {
+            type Output = Self;
+
+            #[inline]
+            fn new(rt: Rt, (base,): (Base,)) -> Self {
+                Self {
+                    rt: rt.into(),
+                    addr: (base.into(), $default_offset),
+                }
+            }
+        }
+    }
 }
 
 macro_rules! define_imm_offset_rules {
@@ -276,6 +280,22 @@ macro_rules! define_unscaled_imm_offset_rules {
                 Self {
                     rt: rt.into(),
                     addr: (base.into(), offset),
+                }
+            }
+        }
+
+        impl<Rt, Base> $make_name<Rt, (Base,)>
+            for $name<$rt, (RegOrSp64, UnscaledOffset)>
+        where
+            Rt: Into<$rt>,
+            Base: Into<RegOrSp64>,
+        {
+            type Output = Self;
+
+            fn new(rt: Rt, (base,): (Base,)) -> Self::Output {
+                Self {
+                    rt: rt.into(),
+                    addr: (base.into(), UnscaledOffset::default()),
                 }
             }
         }
@@ -442,6 +462,24 @@ macro_rules! define_pair_imm_offset_rules {
                 Self {
                     rt: (rt.0.into(), rt.1.into()),
                     addr: (base.into(), offset),
+                }
+            }
+        }
+
+        #[doc = r" `LDP` with 64-bit destination and base register."]
+        impl<Rt1, Rt2, B> $trait_name<Rt1, Rt2, (B,)>
+            for $name<$rt, (RegOrSp64, $offset_type)>
+        where
+            Rt1: Into<$rt>,
+            Rt2: Into<$rt>,
+            B: Into<RegOrSp64>,
+        {
+            type Output = Self;
+            #[inline]
+            fn new(rt: (Rt1, Rt2), (base,): (B,)) -> Self {
+                Self {
+                    rt: (rt.0.into(), rt.1.into()),
+                    addr: (base.into(), <$offset_type>::default()),
                 }
             }
         }

--- a/harm/src/instructions/ldst/stp.rs
+++ b/harm/src/instructions/ldst/stp.rs
@@ -113,6 +113,7 @@ a9000fff	stp xzr, x3, [sp, 0]
 291f8fff	stp wzr, w3, [sp, 252]
 29200fff	stp wzr, w3, [sp, -256]
 29000fff	stp wzr, w3, [sp, 0]
+a9000c41	stp x1, x3, [x2]
 ";
 
     const STP_PRE_POST_INC_DB: &str = "
@@ -145,6 +146,7 @@ a9a003e1	stp x1, x0, [sp, #-0x200]!
         test_stp_x1_x2_504, stp(X1, X3, (X2, 504i32)).unwrap(), "stp x1, x3, [x2, 504]";
         test_stp_x1_x2_m256, stp(X1, X3, (X2, -256i32)).unwrap(), "stp x1, x3, [x2, -256]";
         test_stp_x1_x2_0, stp(X1, X3, (X2, 0i32)).unwrap(), "stp x1, x3, [x2, 0]";
+        test_stp_x1_x2_simple, stp(X1, X3, (X2,)), "stp x1, x3, [x2]";
         test_stp_x1_sp_m8, stp(X1, X3, (SP, -8i32)).unwrap(), "stp x1, x3, [sp, -8]";
         test_stp_x1_sp_8, stp(X1, X3, (SP, 8i32)).unwrap(), "stp x1, x3, [sp, 8]";
         test_stp_x1_sp_504, stp(X1, X3, (SP, 504i32)).unwrap(), "stp x1, x3, [sp, 504]";

--- a/harm/src/instructions/ldst/str.rs
+++ b/harm/src/instructions/ldst/str.rs
@@ -158,6 +158,8 @@ define_reg_offset_rules!(Str, MakeStr, Str, RegOrZero32, 32);
 //
 // ## LDR (immediate offset)
 //
+define_simple_rules!(Str, MakeStr, RegOrZero64, ScaledOffset64, ScaledOffset64::default());
+define_simple_rules!(Str, MakeStr, RegOrZero32, ScaledOffset32, ScaledOffset32::default());
 define_imm_offset_rules!(Str, MakeStr, Str, RegOrZero64, 64, ScaledOffset64);
 define_imm_offset_rules!(Str, MakeStr, Str, RegOrZero32, 32, ScaledOffset32);
 
@@ -243,6 +245,7 @@ b9019102	str w2, [x8, #0x190]
 b901911f	str wzr, [x8, #0x190]
 b90193e2	str w2, [sp, #0x190]
 f900c902	str x2, [x8, #0x190]
+f9000102	str x2, [x8]
 f900cbe2	str x2, [sp, #0x190]
 f900cbff	str xzr, [sp, #0x190]
 ";
@@ -326,6 +329,7 @@ f81d6fe1	str x1, [sp, #-0x2a]!
         test_str_r64_sp_scaled_imm3, str(X2, (SP, 0x190i32)).unwrap(), "str x2, [sp, #0x190]";
         test_str_wzr_r64_scaled_imm3, str(WZR, (X8, 0x190i32)).unwrap(), "str wzr, [x8, #0x190]";
         test_str_xzr_sp_scaled_imm3, str(XZR, (SP, 0x190i32)).unwrap(), "str xzr, [sp, #0x190]";
+        test_str_r64_r64_simple, str(X2, (X8,)), "str x2, [x8]";
     }
 
     test_cases! {

--- a/harm/src/instructions/ldst/str.rs
+++ b/harm/src/instructions/ldst/str.rs
@@ -158,20 +158,6 @@ define_reg_offset_rules!(Str, MakeStr, Str, RegOrZero32, 32);
 //
 // ## LDR (immediate offset)
 //
-define_simple_rules!(
-    Str,
-    MakeStr,
-    RegOrZero64,
-    ScaledOffset64,
-    ScaledOffset64::default()
-);
-define_simple_rules!(
-    Str,
-    MakeStr,
-    RegOrZero32,
-    ScaledOffset32,
-    ScaledOffset32::default()
-);
 define_imm_offset_rules!(Str, MakeStr, Str, RegOrZero64, 64, ScaledOffset64);
 define_imm_offset_rules!(Str, MakeStr, Str, RegOrZero32, 32, ScaledOffset32);
 

--- a/harm/src/instructions/ldst/str.rs
+++ b/harm/src/instructions/ldst/str.rs
@@ -158,8 +158,20 @@ define_reg_offset_rules!(Str, MakeStr, Str, RegOrZero32, 32);
 //
 // ## LDR (immediate offset)
 //
-define_simple_rules!(Str, MakeStr, RegOrZero64, ScaledOffset64, ScaledOffset64::default());
-define_simple_rules!(Str, MakeStr, RegOrZero32, ScaledOffset32, ScaledOffset32::default());
+define_simple_rules!(
+    Str,
+    MakeStr,
+    RegOrZero64,
+    ScaledOffset64,
+    ScaledOffset64::default()
+);
+define_simple_rules!(
+    Str,
+    MakeStr,
+    RegOrZero32,
+    ScaledOffset32,
+    ScaledOffset32::default()
+);
 define_imm_offset_rules!(Str, MakeStr, Str, RegOrZero64, 64, ScaledOffset64);
 define_imm_offset_rules!(Str, MakeStr, Str, RegOrZero32, 32, ScaledOffset32);
 

--- a/harm/src/instructions/ldst/strb.rs
+++ b/harm/src/instructions/ldst/strb.rs
@@ -113,6 +113,13 @@ define_reg_offset_rules!(Strb, MakeStrb, STRB, RegOrZero32, "32B", ByteShift);
 //
 // ## STRB (immediate offset)
 //
+define_simple_rules!(
+    Strb,
+    MakeStrb,
+    RegOrZero32,
+    ScaledOffset8,
+    ScaledOffset8::default()
+);
 define_imm_offset_rules!(Strb, MakeStrb, STRB, RegOrZero32, "32", ScaledOffset8);
 
 //
@@ -168,6 +175,7 @@ mod tests {
 39064102	strb w2, [x8, #0x190]
 3906411f	strb wzr, [x8, #0x190]
 390643e2	strb w2, [sp, #0x190]
+39000102	strb w2, [x8]
 ";
 
     const STRB_PRE_POST_INC_DB: &str = "
@@ -206,6 +214,7 @@ mod tests {
         test_strb_wzr_r64_scaled_imm2, strb(WZR, (X8, 0x190u32)).unwrap(), "strb wzr, [x8, #0x190]";
         test_strb_r32_r64_scaled_imm3, strb(W2, (X8, 0x190i32)).unwrap(), "strb w2, [x8, #0x190]";
         test_strb_wzr_r64_scaled_imm3, strb(WZR, (X8, 0x190i32)).unwrap(), "strb wzr, [x8, #0x190]";
+        test_strb_r32_r64_simple, strb(W2, (X8,)), "strb w2, [x8]";
     }
 
     test_cases! {

--- a/harm/src/instructions/ldst/strb.rs
+++ b/harm/src/instructions/ldst/strb.rs
@@ -113,13 +113,6 @@ define_reg_offset_rules!(Strb, MakeStrb, STRB, RegOrZero32, "32B", ByteShift);
 //
 // ## STRB (immediate offset)
 //
-define_simple_rules!(
-    Strb,
-    MakeStrb,
-    RegOrZero32,
-    ScaledOffset8,
-    ScaledOffset8::default()
-);
 define_imm_offset_rules!(Strb, MakeStrb, STRB, RegOrZero32, "32", ScaledOffset8);
 
 //

--- a/harm/src/instructions/ldst/strh.rs
+++ b/harm/src/instructions/ldst/strh.rs
@@ -115,13 +115,6 @@ define_reg_offset_rules!(Strh, MakeStrh, STRH, RegOrZero32, "32", HalfShift);
 //
 // ## STRH (immediate offset)
 //
-define_simple_rules!(
-    Strh,
-    MakeStrh,
-    RegOrZero32,
-    ScaledOffset16,
-    ScaledOffset16::default()
-);
 define_imm_offset_rules!(Strh, MakeStrh, STRH, RegOrZero32, "32", ScaledOffset16);
 
 //

--- a/harm/src/instructions/ldst/strh.rs
+++ b/harm/src/instructions/ldst/strh.rs
@@ -115,6 +115,13 @@ define_reg_offset_rules!(Strh, MakeStrh, STRH, RegOrZero32, "32", HalfShift);
 //
 // ## STRH (immediate offset)
 //
+define_simple_rules!(
+    Strh,
+    MakeStrh,
+    RegOrZero32,
+    ScaledOffset16,
+    ScaledOffset16::default()
+);
 define_imm_offset_rules!(Strh, MakeStrh, STRH, RegOrZero32, "32", ScaledOffset16);
 
 //
@@ -174,6 +181,7 @@ mod tests {
 79032102	strh w2, [x8, #0x190]
 7903211f	strh wzr, [x8, #0x190]
 790323e2	strh w2, [sp, #0x190]
+79000102	strh w2, [x8]
 ";
 
     const STRH_PRE_POST_INC_DB: &str = "
@@ -216,6 +224,7 @@ mod tests {
         test_strh_wzr_r64_scaled_imm2, strh(WZR, (X8, 0x190u32)).unwrap(), "strh wzr, [x8, #0x190]";
         test_strh_r32_r64_scaled_imm3, strh(W2, (X8, 0x190i32)).unwrap(), "strh w2, [x8, #0x190]";
         test_strh_wzr_r64_scaled_imm3, strh(WZR, (X8, 0x190i32)).unwrap(), "strh wzr, [x8, #0x190]";
+        test_strh_r32_r64_simple, strh(W2, (X8,)), "strh w2, [x8]";
     }
 
     test_cases! {

--- a/harm/src/instructions/ldst/stur.rs
+++ b/harm/src/instructions/ldst/stur.rs
@@ -70,6 +70,7 @@ f8001041	stur x1, [x2, 1]
 f80ff041	stur x1, [x2, 255]
 f8100041	stur x1, [x2, -256]
 f8000041	stur x1, [x2, 0]
+f8000041	stur x1, [x2]
 f81ff3e1	stur x1, [sp, -1]
 f80013e1	stur x1, [sp, 1]
 f80ff3e1	stur x1, [sp, 255]
@@ -114,6 +115,7 @@ b80003ff	stur wzr, [sp, 0]
         test_stur_x1_x2_255, stur(X1, (X2, 255)).unwrap(), "stur x1, [x2, 255]";
         test_stur_x1_x2_m256, stur(X1, (X2, -256)).unwrap(), "stur x1, [x2, -256]";
         test_stur_x1_x2_0, stur(X1, (X2, 0)).unwrap(), "stur x1, [x2, 0]";
+        test_stur_x1_x2_simple, stur(X1, (X2,)), "stur x1, [x2]";
         test_stur_x1_sp_m1, stur(X1, (SP, -1)).unwrap(), "stur x1, [sp, -1]";
         test_stur_x1_sp_1, stur(X1, (SP, 1)).unwrap(), "stur x1, [sp, 1]";
         test_stur_x1_sp_255, stur(X1, (SP, 255)).unwrap(), "stur x1, [sp, 255]";

--- a/harm/src/instructions/ldst/sturb.rs
+++ b/harm/src/instructions/ldst/sturb.rs
@@ -65,6 +65,7 @@ mod tests {
 380ff041	sturb w1, [x2, 255]
 38100041	sturb w1, [x2, -256]
 38000041	sturb w1, [x2, 0]
+38000041	sturb w1, [x2]
 381ff3e1	sturb w1, [sp, -1]
 380013e1	sturb w1, [sp, 1]
 380ff3e1	sturb w1, [sp, 255]
@@ -89,6 +90,7 @@ mod tests {
         test_sturb_w1_x2_255, sturb(W1, (X2, 255)).unwrap(), "sturb w1, [x2, 255]";
         test_sturb_w1_x2_m256, sturb(W1, (X2, -256)).unwrap(), "sturb w1, [x2, -256]";
         test_sturb_w1_x2_0, sturb(W1, (X2, 0)).unwrap(), "sturb w1, [x2, 0]";
+        test_sturb_w1_x2_simple, sturb(W1, (X2,)), "sturb w1, [x2]";
         test_sturb_w1_sp_m1, sturb(W1, (SP, -1)).unwrap(), "sturb w1, [sp, -1]";
         test_sturb_w1_sp_1, sturb(W1, (SP, 1)).unwrap(), "sturb w1, [sp, 1]";
         test_sturb_w1_sp_255, sturb(W1, (SP, 255)).unwrap(), "sturb w1, [sp, 255]";

--- a/harm/src/instructions/ldst/sturh.rs
+++ b/harm/src/instructions/ldst/sturh.rs
@@ -65,6 +65,7 @@ mod tests {
 780ff041	sturh w1, [x2, 255]
 78100041	sturh w1, [x2, -256]
 78000041	sturh w1, [x2, 0]
+78000041	sturh w1, [x2]
 781ff3e1	sturh w1, [sp, -1]
 780013e1	sturh w1, [sp, 1]
 780ff3e1	sturh w1, [sp, 255]
@@ -89,6 +90,7 @@ mod tests {
         test_sturh_w1_x2_255, sturh(W1, (X2, 255)).unwrap(), "sturh w1, [x2, 255]";
         test_sturh_w1_x2_m256, sturh(W1, (X2, -256)).unwrap(), "sturh w1, [x2, -256]";
         test_sturh_w1_x2_0, sturh(W1, (X2, 0)).unwrap(), "sturh w1, [x2, 0]";
+        test_sturh_w1_x2_simple, sturh(W1, (X2,)), "sturh w1, [x2]";
         test_sturh_w1_sp_m1, sturh(W1, (SP, -1)).unwrap(), "sturh w1, [sp, -1]";
         test_sturh_w1_sp_1, sturh(W1, (SP, 1)).unwrap(), "sturh w1, [sp, 1]";
         test_sturh_w1_sp_255, sturh(W1, (SP, 255)).unwrap(), "sturh w1, [sp, 255]";


### PR DESCRIPTION
For example, `ldr(X1, (X2,))` or `stp(X1, X2, X3)`.

Closes #24.