### PR TITLE
harm: refactor branch module to control

### DIFF
--- a/harm/src/instructions.rs
+++ b/harm/src/instructions.rs
@@ -8,7 +8,7 @@ use aarchmrs_types::InstructionCode;
 use crate::reloc::Reloc;
 
 pub mod arith;
-pub mod branches;
+pub mod control;
 pub mod ldst;
 
 pub trait RawInstruction {

--- a/harm/src/instructions/control.rs
+++ b/harm/src/instructions/control.rs
@@ -1,0 +1,12 @@
+/* Copyright (C) 2025 Ivan Boldyrev
+ *
+ * This document is licensed under the BSD 3-clause license.
+ */
+
+pub(crate) mod branch_imm;
+pub(crate) mod branch_reg;
+pub(crate) mod testbranch;
+
+pub use self::branch_imm::*;
+pub use self::branch_reg::*;
+pub use self::testbranch::*;

--- a/harm/src/instructions/control/branch_imm.rs
+++ b/harm/src/instructions/control/branch_imm.rs
@@ -3,23 +3,17 @@
  * This document is licensed under the BSD 3-clause license.
  */
 
-pub(crate) mod reg;
-pub(crate) mod testbranch;
-
 use aarchmrs_instructions::A64::control::{
     branch_imm::{B_only_branch_imm::B_only_branch_imm, BL_only_branch_imm::BL_only_branch_imm},
     condbranch::B_only_condbranch::B_only_condbranch, // TODO BC: branch consistent conditionally
 };
 use aarchmrs_types::InstructionCode;
 
-use super::RawInstruction;
 use crate::{
     bits::{BitError, SBitValue},
+    instructions::RawInstruction,
     register::{IntoCode as _, RegOrZero32, RegOrZero64},
 };
-
-pub use self::reg::*;
-pub use self::testbranch::*;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[repr(u8)]

--- a/harm/src/instructions/control/branch_reg.rs
+++ b/harm/src/instructions/control/branch_reg.rs
@@ -9,7 +9,7 @@ use aarchmrs_instructions::A64::control::branch_reg::{
 };
 use aarchmrs_types::InstructionCode;
 
-use super::RawInstruction;
+use crate::instructions::RawInstruction;
 use crate::register::{IntoCode as _, Reg64, RegOrZero64};
 
 #[inline]

--- a/harm/src/instructions/control/testbranch.rs
+++ b/harm/src/instructions/control/testbranch.rs
@@ -8,9 +8,9 @@ use aarchmrs_instructions::A64::control::testbranch::{
 };
 use aarchmrs_types::InstructionCode;
 
-use super::RawInstruction;
 use crate::{
     bits::{SBitValue, UBitValue},
+    instructions::RawInstruction,
     register::{IntoCode as _, RegOrZero32, RegOrZero64},
 };
 


### PR DESCRIPTION
Make it to follow the `aarchmrs-instructions` structure.

Related to #9.