### PR TITLE
harm: introduce `IntoReg`

### DIFF
--- a/harm/src/instructions/arith/add.rs
+++ b/harm/src/instructions/arith/add.rs
@@ -19,7 +19,9 @@ use super::*;
 use crate::{
     bits::BitError,
     instructions::RawInstruction,
-    register::{Reg32, Reg64, RegOrSp32, RegOrSp64, RegOrZero32, RegOrZero64, Register as _},
+    register::{
+        IntoReg, Reg32, Reg64, RegOrSp32, RegOrSp64, RegOrZero32, RegOrZero64, Register as _,
+    },
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/arith/add.rs
+++ b/harm/src/instructions/arith/add.rs
@@ -19,7 +19,7 @@ use super::*;
 use crate::{
     bits::BitError,
     instructions::RawInstruction,
-    register::{IntoCode as _, Reg32, Reg64, RegOrSp32, RegOrSp64, RegOrZero32, RegOrZero64},
+    register::{Reg32, Reg64, RegOrSp32, RegOrSp64, RegOrZero32, RegOrZero64, Register as _},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/arith/macros.rs
+++ b/harm/src/instructions/arith/macros.rs
@@ -59,14 +59,14 @@ macro_rules! define_arith_shift {
 
             impl<Src1, Src2> [<Make $name>]<$ztype, Src1, Src2> for $name<$ztype, $ztype, $ztype>
             where
-                Src1: Into<$ztype>,
-                Src2: Into<$ztype>,
+                Src1: IntoReg<$ztype>,
+                Src2: IntoReg<$ztype>,
             {
                 type Output = Self;
 
                 #[inline]
                 fn new(dst: $ztype, src1: Src1, src2: Src2) -> Self {
-                    Self { dst, src1: src1.into(), src2: src2.into() }
+                    Self { dst, src1: src1.into_reg(), src2: src2.into_reg() }
                 }
             }
 
@@ -85,8 +85,8 @@ macro_rules! define_arith_shift {
 
             impl<Dst, Src1> [<Make $name>]<Dst, Src1, ShiftedReg<$ztype>> for $name<$ztype, $ztype, ShiftedReg<$ztype>>
             where
-                Dst: Into<$ztype>,
-                Src1: Into<$ztype>,
+                Dst: IntoReg<$ztype>,
+                Src1: IntoReg<$ztype>,
             {
                 type Output = Self;
 
@@ -96,15 +96,15 @@ macro_rules! define_arith_shift {
                     src1: Src1,
                     src2: ShiftedReg<$ztype>,
                 ) -> Self {
-                    Self { dst: dst.into(), src1: src1.into(), src2 }
+                    Self { dst: dst.into_reg(), src1: src1.into_reg(), src2 }
                 }
             }
 
             impl<Dst, Src1, Src2> [<Make $name>]<Dst, Src1, (Src2, ShiftMode, ShiftAmount)> for $name<$ztype, $ztype, ShiftedReg<$ztype>>
             where
-                Dst: Into<$ztype>,
-                Src1: Into<$ztype>,
-                Src2: Into<$ztype>,
+                Dst: IntoReg<$ztype>,
+                Src1: IntoReg<$ztype>,
+                Src2: IntoReg<$ztype>,
             {
                 type Output = Self;
 
@@ -114,16 +114,16 @@ macro_rules! define_arith_shift {
                     src1: Src1,
                     (src2, shift_mode, shift_amount): (Src2, ShiftMode, ShiftAmount)
                 ) -> Self {
-                    let src2 = ShiftedReg::new(src2.into()).shift(shift_mode, shift_amount);
-                    Self { dst: dst.into(), src1: src1.into(), src2 }
+                    let src2 = ShiftedReg::new(src2.into_reg()).shift(shift_mode, shift_amount);
+                    Self { dst: dst.into_reg(), src1: src1.into_reg(), src2 }
                 }
             }
 
             impl<Dst, Src1, Src2> [<Make $name>]<Dst, Src1, (Src2, ShiftMode, u32)> for $name<$ztype, $ztype, ShiftedReg<$ztype>>
             where
-                Dst: Into<$ztype>,
-                Src1: Into<$ztype>,
-                Src2: Into<$ztype>,
+                Dst: IntoReg<$ztype>,
+                Src1: IntoReg<$ztype>,
+                Src2: IntoReg<$ztype>,
             {
                 type Output = Result<Self, BitError>;
 
@@ -134,8 +134,8 @@ macro_rules! define_arith_shift {
                     (src2, shift_mode, shift_amount): (Src2, ShiftMode, u32)
                 ) -> Result<Self, BitError> {
                     let shift_amount = shift_amount.try_into()?;
-                    let src2 = ShiftedReg::new(src2.into()).shift(shift_mode, shift_amount);
-                    Ok(Self { dst: dst.into(), src1: src1.into(), src2 })
+                    let src2 = ShiftedReg::new(src2.into_reg()).shift(shift_mode, shift_amount);
+                    Ok(Self { dst: dst.into_reg(), src1: src1.into_reg(), src2 })
                 }
             }
 
@@ -182,8 +182,8 @@ macro_rules! define_arith_imm12 {
             impl<Dst, Src> [<Make $name>]<Dst, Src, u32>
                 for $name<$etype, $etype, $crate::instructions::arith::AddSubImm12>
             where
-                Dst: Into<$etype>,
-                Src: Into<$etype>,
+                Dst: IntoReg<$etype>,
+                Src: IntoReg<$etype>,
             {
                 type Output = Result<Self, (BitError, BitError)>;
 
@@ -191,8 +191,8 @@ macro_rules! define_arith_imm12 {
                 fn new(dst: Dst, src1: Src, src2: u32) -> Self::Output {
                     let imm12 = $crate::instructions::arith::AddSubImm12::try_from(src2)?;
                     Ok(Self {
-                        dst: dst.into(),
-                        src1: src1.into(),
+                        dst: dst.into_reg(),
+                        src1: src1.into_reg(),
                         src2: imm12,
                     })
                 }
@@ -201,8 +201,8 @@ macro_rules! define_arith_imm12 {
             impl<Dst, Src1, Src2> [<Make $name>]<Dst, Src1, Src2>
                 for $name<$etype, $etype, $crate::instructions::arith::AddSubImm12>
             where
-                Dst: Into<$etype>,
-                Src1: Into<$etype>,
+                Dst: IntoReg<$etype>,
+                Src1: IntoReg<$etype>,
                 Src2: Into<$crate::instructions::arith::AddSubImm12>,
             {
                 type Output = Self;
@@ -210,8 +210,8 @@ macro_rules! define_arith_imm12 {
                 #[inline]
                 fn new(dst: Dst, src1: Src1, src2: Src2) -> Self::Output {
                     Self {
-                        dst: dst.into(),
-                        src1: src1.into(),
+                        dst: dst.into_reg(),
+                        src1: src1.into_reg(),
                         src2: src2.into(),
                     }
                 }
@@ -255,14 +255,14 @@ macro_rules! define_arith_extend {
             }
 
             impl<Src1, Src2> [<Make $name>]<$stype, Src1, Src2> for $name<$stype, $stype, $ztype>
-            where Src1: Into<$stype>,
-                  Src2: Into<$ztype>
+            where Src1: IntoReg<$stype>,
+                  Src2: IntoReg<$ztype>
             {
                 type Output = Self;
 
                 #[inline]
                 fn new(dst: $stype, src1: Src1, src2: Src2) -> Self {
-                    Self { dst, src1: src1.into(), src2: src2.into() }
+                    Self { dst, src1: src1.into_reg(), src2: src2.into_reg() }
                 }
             }
 
@@ -327,9 +327,9 @@ macro_rules! define_arith_extend {
             impl<Dst, Src1, Src2> [<Make $name>]<Dst, Src1, (Src2, ExtendMode)>
                 for $name<$stype, $stype, ExtendedReg<$ztype>>
                 where
-                    Dst: Into<$stype>,
-                    Src1: Into<$stype>,
-                    Src2: Into<$ztype>,
+                    Dst: IntoReg<$stype>,
+                    Src1: IntoReg<$stype>,
+                    Src2: IntoReg<$ztype>,
             {
                 type Output = Self;
 
@@ -339,17 +339,17 @@ macro_rules! define_arith_extend {
                     src1: Src1,
                     (src2, mode): (Src2, ExtendMode),
                 ) -> Self {
-                    let src2 = ExtendedReg::new(src2.into()).extend(mode, <_>::default());
-                    Self { dst: dst.into(), src1: src1.into(), src2 }
+                    let src2 = ExtendedReg::new(src2.into_reg()).extend(mode, <_>::default());
+                    Self { dst: dst.into_reg(), src1: src1.into_reg(), src2 }
                 }
             }
 
             impl<Dst, Src1, Src2> [<Make $name>]<Dst, Src1, (Src2, ExtendMode, ExtendShiftAmount)>
                 for $name<$stype, $stype, ExtendedReg<$ztype>>
                 where
-                    Dst: Into<$stype>,
-                    Src1: Into<$stype>,
-                    Src2: Into<$ztype>,
+                    Dst: IntoReg<$stype>,
+                    Src1: IntoReg<$stype>,
+                    Src2: IntoReg<$ztype>,
             {
                 type Output = Self;
 
@@ -359,17 +359,17 @@ macro_rules! define_arith_extend {
                     src1: Src1,
                     (src2, mode, offset): (Src2, ExtendMode, ExtendShiftAmount),
                 ) -> Self::Output {
-                    let src2 = ExtendedReg::new(src2.into()).extend(mode, offset);
-                    Self { dst: dst.into(), src1: src1.into(), src2 }
+                    let src2 = ExtendedReg::new(src2.into_reg()).extend(mode, offset);
+                    Self { dst: dst.into_reg(), src1: src1.into_reg(), src2 }
                 }
             }
 
             impl<Dst, Src1, Src2> [<Make $name>]<Dst, Src1, (Src2, ExtendMode, u8)>
                 for $name<$stype, $stype, ExtendedReg<$ztype>>
                 where
-                    Dst: Into<$stype>,
-                    Src1: Into<$stype>,
-                    Src2: Into<$ztype>,
+                    Dst: IntoReg<$stype>,
+                    Src1: IntoReg<$stype>,
+                    Src2: IntoReg<$ztype>,
             {
                 type Output = Result<Self, ExtendError>;
 

--- a/harm/src/instructions/arith/sub.rs
+++ b/harm/src/instructions/arith/sub.rs
@@ -15,7 +15,7 @@ use super::*;
 use crate::{
     bits::BitError,
     instructions::RawInstruction,
-    register::{IntoCode as _, Reg32, Reg64, RegOrSp32, RegOrSp64, RegOrZero32, RegOrZero64},
+    register::{Reg32, Reg64, RegOrSp32, RegOrSp64, RegOrZero32, RegOrZero64, Register as _},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/arith/sub.rs
+++ b/harm/src/instructions/arith/sub.rs
@@ -15,7 +15,9 @@ use super::*;
 use crate::{
     bits::BitError,
     instructions::RawInstruction,
-    register::{Reg32, Reg64, RegOrSp32, RegOrSp64, RegOrZero32, RegOrZero64, Register as _},
+    register::{
+        IntoReg, Reg32, Reg64, RegOrSp32, RegOrSp64, RegOrZero32, RegOrZero64, Register as _,
+    },
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/control/branch_imm.rs
+++ b/harm/src/instructions/control/branch_imm.rs
@@ -12,7 +12,7 @@ use aarchmrs_types::InstructionCode;
 use crate::{
     bits::{BitError, SBitValue},
     instructions::RawInstruction,
-    register::{IntoCode as _, RegOrZero32, RegOrZero64},
+    register::{RegOrZero32, RegOrZero64, Register as _},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/control/branch_reg.rs
+++ b/harm/src/instructions/control/branch_reg.rs
@@ -10,7 +10,7 @@ use aarchmrs_instructions::A64::control::branch_reg::{
 use aarchmrs_types::InstructionCode;
 
 use crate::instructions::RawInstruction;
-use crate::register::{IntoCode as _, Reg64, RegOrZero64};
+use crate::register::{Reg64, RegOrZero64, Register as _};
 
 #[inline]
 pub fn ret() -> Ret {

--- a/harm/src/instructions/control/branch_reg.rs
+++ b/harm/src/instructions/control/branch_reg.rs
@@ -10,7 +10,7 @@ use aarchmrs_instructions::A64::control::branch_reg::{
 use aarchmrs_types::InstructionCode;
 
 use crate::instructions::RawInstruction;
-use crate::register::{Reg64, RegOrZero64, Register as _};
+use crate::register::{IntoReg, Reg64, RegOrZero64, Register as _};
 
 #[inline]
 pub fn ret() -> Ret {
@@ -28,8 +28,8 @@ impl Ret {
     }
 
     #[inline]
-    pub fn reg(mut self, reg: impl Into<RegOrZero64>) -> Self {
-        self.0 = reg.into();
+    pub fn reg(mut self, reg: impl IntoReg<RegOrZero64>) -> Self {
+        self.0 = reg.into_reg();
         self
     }
 }
@@ -51,8 +51,8 @@ impl RawInstruction for Br {
 }
 
 #[inline]
-pub fn br(reg: impl Into<RegOrZero64>) -> Br {
-    Br(reg.into())
+pub fn br(reg: impl IntoReg<RegOrZero64>) -> Br {
+    Br(reg.into_reg())
 }
 
 pub struct Blr(RegOrZero64);

--- a/harm/src/instructions/control/testbranch.rs
+++ b/harm/src/instructions/control/testbranch.rs
@@ -11,7 +11,7 @@ use aarchmrs_types::InstructionCode;
 use crate::{
     bits::{SBitValue, UBitValue},
     instructions::RawInstruction,
-    register::{RegOrZero32, RegOrZero64, Register as _},
+    register::{IntoReg, RegOrZero32, RegOrZero64, Register as _},
     sealed::Sealed,
 };
 
@@ -28,13 +28,13 @@ pub trait MakeTestBranch<Reg, Bit>: Sealed {
     fn new(op: bool, reg: Reg, bit: Bit, offset: SBitValue<14, 2>) -> Self;
 }
 
-impl<R: Into<RegOrZero64>> MakeTestBranch<R, UBitValue<6>>
+impl<R: IntoReg<RegOrZero64>> MakeTestBranch<R, UBitValue<6>>
     for TestBranch<RegOrZero64, UBitValue<6>>
 {
     fn new(op: bool, reg: R, bit: UBitValue<6>, offset: SBitValue<14, 2>) -> Self {
         Self {
             op,
-            reg: reg.into(),
+            reg: reg.into_reg(),
             bit,
             offset,
         }

--- a/harm/src/instructions/control/testbranch.rs
+++ b/harm/src/instructions/control/testbranch.rs
@@ -11,7 +11,7 @@ use aarchmrs_types::InstructionCode;
 use crate::{
     bits::{SBitValue, UBitValue},
     instructions::RawInstruction,
-    register::{IntoCode as _, RegOrZero32, RegOrZero64},
+    register::{RegOrZero32, RegOrZero64, Register as _},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/ldst/ldp.rs
+++ b/harm/src/instructions/ldst/ldp.rs
@@ -17,7 +17,7 @@ use aarchmrs_instructions::A64::ldst::{
 
 use super::{Inc, LdpStpOffset32, LdpStpOffset64};
 use crate::bits::BitError;
-use crate::register::{RegOrSp64, RegOrZero32, RegOrZero64, Register};
+use crate::register::{IntoReg, RegOrSp64, RegOrZero32, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 /// A `ldp` instruction with a destination and an address.

--- a/harm/src/instructions/ldst/ldp.rs
+++ b/harm/src/instructions/ldst/ldp.rs
@@ -17,7 +17,7 @@ use aarchmrs_instructions::A64::ldst::{
 
 use super::{Inc, LdpStpOffset32, LdpStpOffset64};
 use crate::bits::BitError;
-use crate::register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64};
+use crate::register::{RegOrSp64, RegOrZero32, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 /// A `ldp` instruction with a destination and an address.

--- a/harm/src/instructions/ldst/ldpsw.rs
+++ b/harm/src/instructions/ldst/ldpsw.rs
@@ -11,7 +11,7 @@ use aarchmrs_instructions::A64::ldst::{
 
 use super::{Inc, LdpStpOffset32};
 use crate::bits::BitError;
-use crate::register::{IntoCode as _, RegOrSp64, RegOrZero64};
+use crate::register::{RegOrSp64, RegOrZero64, Register as _};
 use crate::sealed::Sealed;
 
 /// A `ldpsw` instruction with a destination and an address.

--- a/harm/src/instructions/ldst/ldpsw.rs
+++ b/harm/src/instructions/ldst/ldpsw.rs
@@ -11,7 +11,7 @@ use aarchmrs_instructions::A64::ldst::{
 
 use super::{Inc, LdpStpOffset32};
 use crate::bits::BitError;
-use crate::register::{RegOrSp64, RegOrZero64, Register as _};
+use crate::register::{IntoReg, RegOrSp64, RegOrZero64, Register as _};
 use crate::sealed::Sealed;
 
 /// A `ldpsw` instruction with a destination and an address.

--- a/harm/src/instructions/ldst/ldr.rs
+++ b/harm/src/instructions/ldst/ldr.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{ldr, ext, LdStExtendOption32, LdStShift};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! ldr(W1, X2);        // LDR W1, [X2]
@@ -61,8 +61,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{ldr, inc, preinc, postinc, LdStIncOffset};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! ldr(W1, (inc(offset), X2));       // preincrement, LDR W1, [X2, #4]!
 //! ldr(W1, (X2, inc(offset)));       // postincrement, LDR W1, [X2], #4
@@ -123,7 +123,7 @@ use super::shift_extend::*;
 use super::{Inc, LdStIncOffset, ScaledOffset32, ScaledOffset64};
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{RegOrSp64, RegOrZero32, RegOrZero64, Register};
+use crate::register::{IntoReg, RegOrSp64, RegOrZero32, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 /// A `ldr` instruction with a destination and an address.

--- a/harm/src/instructions/ldst/ldr.rs
+++ b/harm/src/instructions/ldst/ldr.rs
@@ -123,7 +123,7 @@ use super::shift_extend::*;
 use super::{Inc, LdStIncOffset, ScaledOffset32, ScaledOffset64};
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64};
+use crate::register::{RegOrSp64, RegOrZero32, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 /// A `ldr` instruction with a destination and an address.

--- a/harm/src/instructions/ldst/ldr.rs
+++ b/harm/src/instructions/ldst/ldr.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{ldr, ext, LdStExtendOption32, LdStShift};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! ldr(W1, X2);        // LDR W1, [X2]
@@ -61,8 +61,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{ldr, inc, preinc, postinc, LdStIncOffset};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! ldr(W1, (inc(offset), X2));       // preincrement, LDR W1, [X2, #4]!
 //! ldr(W1, (X2, inc(offset)));       // postincrement, LDR W1, [X2], #4

--- a/harm/src/instructions/ldst/ldrb.rs
+++ b/harm/src/instructions/ldst/ldrb.rs
@@ -78,7 +78,7 @@ use super::{ByteShift, Inc, LdStIncOffset, ScaledOffset8};
 use crate::{
     bits::BitError,
     instructions::RawInstruction,
-    register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64},
+    register::{RegOrSp64, RegOrZero32, RegOrZero64, Register},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/ldst/ldrb.rs
+++ b/harm/src/instructions/ldst/ldrb.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{ldrb, ext, LdStExtendOption32, LdStShift};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! ldrb(W1, X2);        // LDRB W1, [X2]
@@ -53,8 +53,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{ldrb, inc, preinc, postinc, LdStIncOffset};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! ldrb(W1, (inc(offset), X2));       // preincrement, LDRB W1, [X2, #4]!
 //! ldrb(W1, (X2, inc(offset)));       // postincrement, LDRB W1, [X2], #4
@@ -78,7 +78,7 @@ use super::{ByteShift, Inc, LdStIncOffset, ScaledOffset8};
 use crate::{
     bits::BitError,
     instructions::RawInstruction,
-    register::{RegOrSp64, RegOrZero32, RegOrZero64, Register},
+    register::{IntoReg, RegOrSp64, RegOrZero32, RegOrZero64, Register},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/ldst/ldrb.rs
+++ b/harm/src/instructions/ldst/ldrb.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{ldrb, ext, LdStExtendOption32, LdStShift};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! ldrb(W1, X2);        // LDRB W1, [X2]
@@ -53,8 +53,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{ldrb, inc, preinc, postinc, LdStIncOffset};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! ldrb(W1, (inc(offset), X2));       // preincrement, LDRB W1, [X2, #4]!
 //! ldrb(W1, (X2, inc(offset)));       // postincrement, LDRB W1, [X2], #4

--- a/harm/src/instructions/ldst/ldrh.rs
+++ b/harm/src/instructions/ldst/ldrh.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{ldrh, ext, LdStExtendOption32, LdStShift};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! ldrh(W1, X2);        // LDRH W1, [X2]
@@ -55,8 +55,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{ldrh, inc, preinc, postinc, LdStIncOffset};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! ldrh(W1, (inc(offset), X2));       // preincrement, LDRH W1, [X2, #4]!
 //! ldrh(W1, (X2, inc(offset)));       // postincrement, LDRH W1, [X2], #4

--- a/harm/src/instructions/ldst/ldrh.rs
+++ b/harm/src/instructions/ldst/ldrh.rs
@@ -80,7 +80,7 @@ use super::{HalfShift, Inc, LdStIncOffset, ScaledOffset16};
 use crate::{
     bits::BitError,
     instructions::RawInstruction,
-    register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64},
+    register::{RegOrSp64, RegOrZero32, RegOrZero64, Register},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/ldst/ldrh.rs
+++ b/harm/src/instructions/ldst/ldrh.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{ldrh, ext, LdStExtendOption32, LdStShift};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! ldrh(W1, X2);        // LDRH W1, [X2]
@@ -55,8 +55,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{ldrh, inc, preinc, postinc, LdStIncOffset};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! ldrh(W1, (inc(offset), X2));       // preincrement, LDRH W1, [X2, #4]!
 //! ldrh(W1, (X2, inc(offset)));       // postincrement, LDRH W1, [X2], #4
@@ -80,7 +80,7 @@ use super::{HalfShift, Inc, LdStIncOffset, ScaledOffset16};
 use crate::{
     bits::BitError,
     instructions::RawInstruction,
-    register::{RegOrSp64, RegOrZero32, RegOrZero64, Register},
+    register::{IntoReg, RegOrSp64, RegOrZero32, RegOrZero64, Register},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/ldst/ldrsb.rs
+++ b/harm/src/instructions/ldst/ldrsb.rs
@@ -91,7 +91,7 @@ use super::shift_extend::*;
 use super::{ByteShift, Inc, LdStIncOffset, ScaledOffset8};
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64};
+use crate::register::{RegOrSp64, RegOrZero32, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 /// A `LDRSB` instruction with a destination and an address.

--- a/harm/src/instructions/ldst/ldrsb.rs
+++ b/harm/src/instructions/ldst/ldrsb.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{ldrsb, ext, LdStExtendOption32, LdStShift};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! ldrsb(W1, X2);        // LDRSB W1, [X2]
@@ -60,8 +60,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{ldrsb, inc, preinc, postinc, LdStIncOffset};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! ldrsb(W1, (inc(offset), X2));       // preincrement, LDRSB W1, [X2, #4]!
 //! ldrsb(W1, (X2, inc(offset)));       // postincrement, LDRSB W1, [X2], #4

--- a/harm/src/instructions/ldst/ldrsb.rs
+++ b/harm/src/instructions/ldst/ldrsb.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{ldrsb, ext, LdStExtendOption32, LdStShift};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! ldrsb(W1, X2);        // LDRSB W1, [X2]
@@ -60,8 +60,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{ldrsb, inc, preinc, postinc, LdStIncOffset};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! ldrsb(W1, (inc(offset), X2));       // preincrement, LDRSB W1, [X2, #4]!
 //! ldrsb(W1, (X2, inc(offset)));       // postincrement, LDRSB W1, [X2], #4
@@ -91,7 +91,7 @@ use super::shift_extend::*;
 use super::{ByteShift, Inc, LdStIncOffset, ScaledOffset8};
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{RegOrSp64, RegOrZero32, RegOrZero64, Register};
+use crate::register::{IntoReg, RegOrSp64, RegOrZero32, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 /// A `LDRSB` instruction with a destination and an address.

--- a/harm/src/instructions/ldst/ldrsh.rs
+++ b/harm/src/instructions/ldst/ldrsh.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{ldrsh, ext, LdStExtendOption32, LdStShift};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! ldrsh(W1, X2);        // LDRSH W1, [X2]
@@ -60,8 +60,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{ldrsh, inc, preinc, postinc, LdStIncOffset};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! ldrsh(W1, (inc(offset), X2));       // preincrement, LDRSH W1, [X2, #4]!
 //! ldrsh(W1, (X2, inc(offset)));       // postincrement, LDRSH W1, [X2], #4

--- a/harm/src/instructions/ldst/ldrsh.rs
+++ b/harm/src/instructions/ldst/ldrsh.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{ldrsh, ext, LdStExtendOption32, LdStShift};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! ldrsh(W1, X2);        // LDRSH W1, [X2]
@@ -60,8 +60,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{ldrsh, inc, preinc, postinc, LdStIncOffset};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! ldrsh(W1, (inc(offset), X2));       // preincrement, LDRSH W1, [X2, #4]!
 //! ldrsh(W1, (X2, inc(offset)));       // postincrement, LDRSH W1, [X2], #4
@@ -92,7 +92,7 @@ use super::{HalfShift, Inc, LdStIncOffset, ScaledOffset16};
 use crate::{
     bits::BitError,
     instructions::RawInstruction,
-    register::{RegOrSp64, RegOrZero32, RegOrZero64, Register},
+    register::{IntoReg, RegOrSp64, RegOrZero32, RegOrZero64, Register},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/ldst/ldrsh.rs
+++ b/harm/src/instructions/ldst/ldrsh.rs
@@ -92,7 +92,7 @@ use super::{HalfShift, Inc, LdStIncOffset, ScaledOffset16};
 use crate::{
     bits::BitError,
     instructions::RawInstruction,
-    register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64},
+    register::{RegOrSp64, RegOrZero32, RegOrZero64, Register},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/ldst/ldrsw.rs
+++ b/harm/src/instructions/ldst/ldrsw.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{ldrsw, ext, LdStExtendOption32, LdStShift};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! ldrsw(X1, X2);        // LDRSW W1, [X2]
@@ -57,8 +57,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{ldrsw, inc, preinc, postinc, LdStIncOffset};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! ldrsw(X1, (inc(offset), X2));       // preincrement, LDRSW X1, [X2, #4]!
 //! ldrsw(X1, (X2, inc(offset)));       // postincrement, LDRSW X1, [X2], #4

--- a/harm/src/instructions/ldst/ldrsw.rs
+++ b/harm/src/instructions/ldst/ldrsw.rs
@@ -117,7 +117,7 @@ use super::shift_extend::*;
 use super::{Inc, LdStIncOffset, ScaledOffset32};
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64};
+use crate::register::{RegOrSp64, RegOrZero32, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 /// A `ldrsw` instruction with a destination and an address.

--- a/harm/src/instructions/ldst/ldrsw.rs
+++ b/harm/src/instructions/ldst/ldrsw.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{ldrsw, ext, LdStExtendOption32, LdStShift};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! ldrsw(X1, X2);        // LDRSW W1, [X2]
@@ -57,8 +57,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{ldrsw, inc, preinc, postinc, LdStIncOffset};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! ldrsw(X1, (inc(offset), X2));       // preincrement, LDRSW X1, [X2, #4]!
 //! ldrsw(X1, (X2, inc(offset)));       // postincrement, LDRSW X1, [X2], #4
@@ -117,7 +117,7 @@ use super::shift_extend::*;
 use super::{Inc, LdStIncOffset, ScaledOffset32};
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{RegOrSp64, RegOrZero32, RegOrZero64, Register};
+use crate::register::{IntoReg, RegOrSp64, RegOrZero32, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 /// A `ldrsw` instruction with a destination and an address.

--- a/harm/src/instructions/ldst/ldur.rs
+++ b/harm/src/instructions/ldst/ldur.rs
@@ -9,7 +9,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::{
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{RegOrSp64, RegOrZero32, RegOrZero64, Register};
+use crate::register::{IntoReg, RegOrSp64, RegOrZero32, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/instructions/ldst/ldur.rs
+++ b/harm/src/instructions/ldst/ldur.rs
@@ -9,7 +9,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::{
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64};
+use crate::register::{RegOrSp64, RegOrZero32, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/instructions/ldst/ldurb.rs
+++ b/harm/src/instructions/ldst/ldurb.rs
@@ -7,7 +7,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::LDURB_32_ldst_unscaled::LDU
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{RegOrSp64, RegOrZero32, Register};
+use crate::register::{IntoReg, RegOrSp64, RegOrZero32, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/instructions/ldst/ldurb.rs
+++ b/harm/src/instructions/ldst/ldurb.rs
@@ -7,7 +7,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::LDURB_32_ldst_unscaled::LDU
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{IntoCode, RegOrSp64, RegOrZero32};
+use crate::register::{RegOrSp64, RegOrZero32, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/instructions/ldst/ldurh.rs
+++ b/harm/src/instructions/ldst/ldurh.rs
@@ -7,7 +7,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::LDURH_32_ldst_unscaled::LDU
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{RegOrSp64, RegOrZero32, Register};
+use crate::register::{IntoReg, RegOrSp64, RegOrZero32, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/instructions/ldst/ldurh.rs
+++ b/harm/src/instructions/ldst/ldurh.rs
@@ -7,7 +7,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::LDURH_32_ldst_unscaled::LDU
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{IntoCode, RegOrSp64, RegOrZero32};
+use crate::register::{RegOrSp64, RegOrZero32, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/instructions/ldst/ldursb.rs
+++ b/harm/src/instructions/ldst/ldursb.rs
@@ -10,7 +10,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::{
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{RegOrSp64, RegOrZero32, RegOrZero64, Register};
+use crate::register::{IntoReg, RegOrSp64, RegOrZero32, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/instructions/ldst/ldursb.rs
+++ b/harm/src/instructions/ldst/ldursb.rs
@@ -10,7 +10,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::{
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64};
+use crate::register::{RegOrSp64, RegOrZero32, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/instructions/ldst/ldursh.rs
+++ b/harm/src/instructions/ldst/ldursh.rs
@@ -10,7 +10,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::{
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{RegOrSp64, RegOrZero32, RegOrZero64, Register};
+use crate::register::{IntoReg, RegOrSp64, RegOrZero32, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/instructions/ldst/ldursh.rs
+++ b/harm/src/instructions/ldst/ldursh.rs
@@ -10,7 +10,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::{
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64};
+use crate::register::{RegOrSp64, RegOrZero32, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/instructions/ldst/ldursw.rs
+++ b/harm/src/instructions/ldst/ldursw.rs
@@ -7,7 +7,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::LDURSW_64_ldst_unscaled::LD
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{IntoCode, RegOrSp64, RegOrZero64};
+use crate::register::{RegOrSp64, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/instructions/ldst/ldursw.rs
+++ b/harm/src/instructions/ldst/ldursw.rs
@@ -7,7 +7,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::LDURSW_64_ldst_unscaled::LD
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{RegOrSp64, RegOrZero64, Register};
+use crate::register::{IntoReg, RegOrSp64, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/instructions/ldst/macros.rs
+++ b/harm/src/instructions/ldst/macros.rs
@@ -12,8 +12,8 @@ macro_rules! define_reg_offset_rules {
         impl<Rt, Base, Ext> $trait_name<Rt, (Base, Ext)>
             for $name<$rt, (RegOrSp64, Extended<$shift, RegOrZero64>)>
         where
-            Rt: Into<$rt>,
-            Base: Into<RegOrSp64>,
+            Rt: IntoReg<$rt>,
+            Base: IntoReg<RegOrSp64>,
             Ext: Into<Extended<$shift, RegOrZero64>>,
         {
             type Output = Self;
@@ -21,8 +21,8 @@ macro_rules! define_reg_offset_rules {
             #[inline]
             fn new(rt: Rt, (base, offset): (Base, Ext)) -> Self {
                 Self {
-                    rt: rt.into(),
-                    addr: (base.into(), offset.into()),
+                    rt: rt.into_reg(),
+                    addr: (base.into_reg(), offset.into()),
                 }
             }
         }
@@ -31,8 +31,8 @@ macro_rules! define_reg_offset_rules {
         impl<Rt, Base, Ext> $trait_name<Rt, (Base, Ext)>
             for $name<$rt, (RegOrSp64, Extended<$shift, RegOrZero32>)>
         where
-            Rt: Into<$rt>,
-            Base: Into<RegOrSp64>,
+            Rt: IntoReg<$rt>,
+            Base: IntoReg<RegOrSp64>,
             Ext: Into<Extended<$shift, RegOrZero32>>,
         {
             type Output = Self;
@@ -40,8 +40,8 @@ macro_rules! define_reg_offset_rules {
             #[inline]
             fn new(rt: Rt, (base, offset): (Base, Ext)) -> Self {
                 Self {
-                    rt: rt.into(),
-                    addr: (base.into(), offset.into()),
+                    rt: rt.into_reg(),
+                    addr: (base.into_reg(), offset.into()),
                 }
             }
         }
@@ -50,17 +50,17 @@ macro_rules! define_reg_offset_rules {
         impl<Rt, Base, OffsetReg> $trait_name<Rt, (Base, OffsetReg)>
             for $name<$rt, (RegOrSp64, RegOrZero64)>
         where
-            Rt: Into<$rt>,
-            Base: Into<RegOrSp64>,
-            OffsetReg: Into<RegOrZero64>,
+            Rt: IntoReg<$rt>,
+            Base: IntoReg<RegOrSp64>,
+            OffsetReg: IntoReg<RegOrZero64>,
         {
             type Output = Self;
 
             #[inline]
             fn new(rt: Rt, (base, offset): (Base, OffsetReg)) -> Self {
                 Self {
-                    rt: rt.into(),
-                    addr: (base.into(), offset.into()),
+                    rt: rt.into_reg(),
+                    addr: (base.into_reg(), offset.into_reg()),
                 }
             }
         }
@@ -116,16 +116,16 @@ macro_rules! define_imm_offset_rules {
         /// `LDR` with 64-bit destination, bare base register.
         impl<Rt, Base> $trait_name<Rt, Base> for $name<$rt, (RegOrSp64, $offset_type)>
         where
-            Rt: Into<$rt>,
-            Base: Into<RegOrSp64>,
+            Rt: IntoReg<$rt>,
+            Base: IntoReg<RegOrSp64>,
         {
             type Output = Self;
 
             #[inline]
             fn new(rt: Rt, base: Base) -> Self {
                 Self {
-                    rt: rt.into(),
-                    addr: (base.into(), <$offset_type>::default()),
+                    rt: rt.into_reg(),
+                    addr: (base.into_reg(), <$offset_type>::default()),
                 }
             }
         }
@@ -133,16 +133,16 @@ macro_rules! define_imm_offset_rules {
         /// `LDR` with 64-bit destination, bare base register as a tuple.
         impl<Rt, Base> $trait_name<Rt, (Base,)> for $name<$rt, (RegOrSp64, $offset_type)>
         where
-            Rt: Into<$rt>,
-            Base: Into<RegOrSp64>,
+            Rt: IntoReg<$rt>,
+            Base: IntoReg<RegOrSp64>,
         {
             type Output = Self;
 
             #[inline]
             fn new(rt: Rt, (base,): (Base,)) -> Self {
                 Self {
-                    rt: rt.into(),
-                    addr: (base.into(), <$offset_type>::default()),
+                    rt: rt.into_reg(),
+                    addr: (base.into_reg(), <$offset_type>::default()),
                 }
             }
         }
@@ -151,16 +151,16 @@ macro_rules! define_imm_offset_rules {
         impl<Rt, B> $trait_name<Rt, (B, $offset_type)>
             for $name<$rt, (RegOrSp64, $offset_type)>
         where
-            Rt: Into<$rt>,
-            B: Into<RegOrSp64>,
+            Rt: IntoReg<$rt>,
+            B: IntoReg<RegOrSp64>,
         {
             type Output = Self;
 
             #[inline]
             fn new(rt: Rt, (base, offset): (B, $offset_type)) -> Self {
                 Self {
-                    rt: rt.into(),
-                    addr: (base.into(), offset),
+                    rt: rt.into_reg(),
+                    addr: (base.into_reg(), offset),
                 }
             }
         }
@@ -169,8 +169,8 @@ macro_rules! define_imm_offset_rules {
         /// specific range and alignment.
         impl<Rt, B> $trait_name<Rt, (B, u32)> for $name<$rt, (RegOrSp64, $offset_type)>
         where
-            Rt: Into<$rt>,
-            B: Into<RegOrSp64>,
+            Rt: IntoReg<$rt>,
+            B: IntoReg<RegOrSp64>,
         {
             type Output = Result<Self, BitError>;
 
@@ -178,8 +178,8 @@ macro_rules! define_imm_offset_rules {
             fn new(rt: Rt, (base, offset): (B, u32)) -> Self::Output {
                 let offset = <$offset_type>::try_from(offset)?;
                 Ok(Self {
-                    rt: rt.into(),
-                    addr: (base.into(), offset),
+                    rt: rt.into_reg(),
+                    addr: (base.into_reg(), offset),
                 })
             }
         }
@@ -188,8 +188,8 @@ macro_rules! define_imm_offset_rules {
         /// specific range and alignment.
         impl<Rt, B> $trait_name<Rt, (B, i32)> for $name<$rt, (RegOrSp64, $offset_type)>
         where
-            Rt: Into<$rt>,
-            B: Into<RegOrSp64>,
+            Rt: IntoReg<$rt>,
+            B: IntoReg<RegOrSp64>,
         {
             type Output = Result<Self, BitError>;
 
@@ -197,34 +197,34 @@ macro_rules! define_imm_offset_rules {
             fn new(rt: Rt, (base, offset): (B, i32)) -> Self::Output {
                 let offset = <$offset_type>::try_from(offset)?;
                 Ok(Self {
-                    rt: rt.into(),
-                    addr: (base.into(), offset),
+                    rt: rt.into_reg(),
+                    addr: (base.into_reg(), offset),
                 })
             }
         }
 
-        impl<Rt: Into<$rt>, Base: Into<RegOrSp64>> $trait_name<Rt, (Inc<LdStIncOffset>, Base)>
+        impl<Rt: IntoReg<$rt>, Base: IntoReg<RegOrSp64>> $trait_name<Rt, (Inc<LdStIncOffset>, Base)>
             for $name<$rt, (Inc<LdStIncOffset>, RegOrSp64)>
         {
             type Output = Self;
 
             fn new(rt: Rt, (inc, base): (Inc<LdStIncOffset>, Base)) -> Self {
                 Self {
-                    rt: rt.into(),
-                    addr: (inc, base.into()),
+                    rt: rt.into_reg(),
+                    addr: (inc, base.into_reg()),
                 }
             }
         }
 
-        impl<Rt: Into<$rt>, Base: Into<RegOrSp64>> $trait_name<Rt, (Base, Inc<LdStIncOffset>)>
+        impl<Rt: IntoReg<$rt>, Base: IntoReg<RegOrSp64>> $trait_name<Rt, (Base, Inc<LdStIncOffset>)>
             for $name<$rt, (RegOrSp64, Inc<LdStIncOffset>)>
         {
             type Output = Self;
 
             fn new(rt: Rt, (base, inc): (Base, Inc<LdStIncOffset>)) -> Self {
                 Self {
-                    rt: rt.into(),
-                    addr: (base.into(), inc),
+                    rt: rt.into_reg(),
+                    addr: (base.into_reg(), inc),
                 }
             }
         }
@@ -266,15 +266,15 @@ macro_rules! define_unscaled_imm_offset_rules {
         impl<Rt, Base> $make_name<Rt, (Base, UnscaledOffset)>
             for $name<$rt, (RegOrSp64, UnscaledOffset)>
         where
-            Rt: Into<$rt>,
-            Base: Into<RegOrSp64>,
+            Rt: IntoReg<$rt>,
+            Base: IntoReg<RegOrSp64>,
         {
             type Output = Self;
 
             fn new(rt: Rt, (base, offset): (Base, UnscaledOffset)) -> Self::Output {
                 Self {
-                    rt: rt.into(),
-                    addr: (base.into(), offset),
+                    rt: rt.into_reg(),
+                    addr: (base.into_reg(), offset),
                 }
             }
         }
@@ -282,15 +282,15 @@ macro_rules! define_unscaled_imm_offset_rules {
         impl<Rt, Base> $make_name<Rt, Base>
             for $name<$rt, (RegOrSp64, UnscaledOffset)>
         where
-            Rt: Into<$rt>,
-            Base: Into<RegOrSp64>,
+            Rt: IntoReg<$rt>,
+            Base: IntoReg<RegOrSp64>,
         {
             type Output = Self;
 
             fn new(rt: Rt, base: Base) -> Self::Output {
                 Self {
-                    rt: rt.into(),
-                    addr: (base.into(), UnscaledOffset::default()),
+                    rt: rt.into_reg(),
+                    addr: (base.into_reg(), UnscaledOffset::default()),
                 }
             }
         }
@@ -298,15 +298,15 @@ macro_rules! define_unscaled_imm_offset_rules {
         impl<Rt, Base> $make_name<Rt, (Base,)>
             for $name<$rt, (RegOrSp64, UnscaledOffset)>
         where
-            Rt: Into<$rt>,
-            Base: Into<RegOrSp64>,
+            Rt: IntoReg<$rt>,
+            Base: IntoReg<RegOrSp64>,
         {
             type Output = Self;
 
             fn new(rt: Rt, (base,): (Base,)) -> Self::Output {
                 Self {
-                    rt: rt.into(),
-                    addr: (base.into(), UnscaledOffset::default()),
+                    rt: rt.into_reg(),
+                    addr: (base.into_reg(), UnscaledOffset::default()),
                 }
             }
         }
@@ -314,15 +314,15 @@ macro_rules! define_unscaled_imm_offset_rules {
         impl<Rt, Base> $make_name<Rt, (Base, i32)>
             for $name<$rt, (RegOrSp64, UnscaledOffset)>
         where
-            Rt: Into<$rt>,
-            Base: Into<RegOrSp64>,
+            Rt: IntoReg<$rt>,
+            Base: IntoReg<RegOrSp64>,
         {
             type Output = Result<Self, BitError>;
 
             fn new(rt: Rt, (base, offset): (Base, i32)) -> Self::Output {
                 UnscaledOffset::try_from(offset).map(|offset| Self {
-                    rt: rt.into(),
-                    addr: (base.into(), offset),
+                    rt: rt.into_reg(),
+                    addr: (base.into_reg(), offset),
                 })
             }
         }
@@ -347,14 +347,14 @@ macro_rules! define_pc_offset_rules {
         impl<Rt> $trait_name<Rt, ($crate::instructions::ldst::Pc, $crate::instructions::ldst::LdStPcOffset)>
             for $name<$rt, ($crate::instructions::ldst::Pc, $crate::instructions::ldst::LdStPcOffset)>
         where
-            Rt: ::core::convert::Into<$rt>,
+            Rt: IntoReg<$rt>,
         {
             type Output = Self;
 
             #[inline]
             fn new(rt: Rt, addr: ($crate::instructions::ldst::Pc, $crate::instructions::ldst::LdStPcOffset)) -> Self {
                 Self {
-                    rt: rt.into(),
+                    rt: rt.into_reg(),
                     addr,
                 }
             }
@@ -366,14 +366,14 @@ macro_rules! define_pc_offset_rules {
         impl<Rt> $trait_name<Rt, ($crate::instructions::ldst::Pc, i32)>
             for $name<$rt, ($crate::instructions::ldst::Pc, $crate::instructions::ldst::LdStPcOffset)>
         where
-            Rt: ::core::convert::Into<$rt>,
+            Rt: IntoReg<$rt>,
         {
             type Output = ::core::result::Result<Self, $crate::bits::BitError>;
 
             #[inline]
             fn new(rt: Rt, (pc, offset): ($crate::instructions::ldst::Pc, i32)) -> Self::Output {
                 $crate::instructions::ldst::LdStPcOffset::try_from(offset).map(|offset| Self {
-                    rt: rt.into(),
+                    rt: rt.into_reg(),
                     addr: (pc, offset)
                 })
             }
@@ -402,7 +402,7 @@ macro_rules! define_fallible_rules {
             for $name<RtOut, ($crate::register::RegOrSp64, Ext)>
         where
             $name<RtOut, ($crate::register::RegOrSp64, Ext)>: $trait_name<RtInp, (BaseInp, Ext)>,
-            $crate::register::RegOrSp64: From<BaseInp>,
+            BaseInp: IntoReg<$crate::register::RegOrSp64>,
         {
             type Output =
                 ::core::result::Result<<Self as $trait_name<RtInp, (BaseInp, Ext)>>::Output, Err>;
@@ -424,7 +424,7 @@ macro_rules! define_fallible_rules {
             for $name<RtOut, (Ext, $crate::register::RegOrSp64)>
         where
             $name<RtOut, (Ext, $crate::register::RegOrSp64)>: $trait_name<RtInp, (Ext, BaseInp)>,
-            $crate::register::RegOrSp64: From<BaseInp>,
+            BaseInp: IntoReg<$crate::register::RegOrSp64>,
         {
             type Output =
                 ::core::result::Result<<Self as $trait_name<RtInp, (Ext, BaseInp)>>::Output, Err>;
@@ -463,16 +463,16 @@ macro_rules! define_pair_imm_offset_rules {
         impl<Rt1, Rt2, B> $trait_name<Rt1, Rt2, (B, $offset_type)>
             for $name<$rt, (RegOrSp64, $offset_type)>
         where
-            Rt1: Into<$rt>,
-            Rt2: Into<$rt>,
-            B: Into<RegOrSp64>,
+            Rt1: IntoReg<$rt>,
+            Rt2: IntoReg<$rt>,
+            B: IntoReg<RegOrSp64>,
         {
             type Output = Self;
             #[inline]
             fn new(rt: (Rt1, Rt2), (base, offset): (B, $offset_type)) -> Self {
                 Self {
-                    rt: (rt.0.into(), rt.1.into()),
-                    addr: (base.into(), offset),
+                    rt: (rt.0.into_reg(), rt.1.into_reg()),
+                    addr: (base.into_reg(), offset),
                 }
             }
         }
@@ -481,16 +481,16 @@ macro_rules! define_pair_imm_offset_rules {
         impl<Rt1, Rt2, B> $trait_name<Rt1, Rt2, B>
             for $name<$rt, (RegOrSp64, $offset_type)>
         where
-            Rt1: Into<$rt>,
-            Rt2: Into<$rt>,
-            B: Into<RegOrSp64>,
+            Rt1: IntoReg<$rt>,
+            Rt2: IntoReg<$rt>,
+            B: IntoReg<RegOrSp64>,
         {
             type Output = Self;
             #[inline]
             fn new(rt: (Rt1, Rt2), base: B) -> Self {
                 Self {
-                    rt: (rt.0.into(), rt.1.into()),
-                    addr: (base.into(), <$offset_type>::default()),
+                    rt: (rt.0.into_reg(), rt.1.into_reg()),
+                    addr: (base.into_reg(), <$offset_type>::default()),
                 }
             }
         }
@@ -499,16 +499,16 @@ macro_rules! define_pair_imm_offset_rules {
         impl<Rt1, Rt2, B> $trait_name<Rt1, Rt2, (B,)>
             for $name<$rt, (RegOrSp64, $offset_type)>
         where
-            Rt1: Into<$rt>,
-            Rt2: Into<$rt>,
-            B: Into<RegOrSp64>,
+            Rt1: IntoReg<$rt>,
+            Rt2: IntoReg<$rt>,
+            B: IntoReg<RegOrSp64>,
         {
             type Output = Self;
             #[inline]
             fn new(rt: (Rt1, Rt2), (base,): (B,)) -> Self {
                 Self {
-                    rt: (rt.0.into(), rt.1.into()),
-                    addr: (base.into(), <$offset_type>::default()),
+                    rt: (rt.0.into_reg(), rt.1.into_reg()),
+                    addr: (base.into_reg(), <$offset_type>::default()),
                 }
             }
         }
@@ -517,41 +517,41 @@ macro_rules! define_pair_imm_offset_rules {
         #[doc = r" specific range and alignment."]
         impl<Rt1, Rt2, B> $trait_name<Rt1, Rt2, (B, i32)> for $name<$rt, (RegOrSp64, $offset_type)>
         where
-            Rt1: Into<$rt>,
-            Rt2: Into<$rt>,
-            B: Into<RegOrSp64>,
+            Rt1: IntoReg<$rt>,
+            Rt2: IntoReg<$rt>,
+            B: IntoReg<RegOrSp64>,
         {
             type Output = Result<Self, BitError>;
             #[inline]
             fn new(rt: (Rt1, Rt2), (base, offset): (B, i32)) -> Self::Output {
                 let offset = <$offset_type>::try_from(offset)?;
                 Ok(Self {
-                    rt: (rt.0.into(), rt.1.into()),
-                    addr: (base.into(), offset),
+                    rt: (rt.0.into_reg(), rt.1.into_reg()),
+                    addr: (base.into_reg(), offset),
                 })
             }
         }
-        impl<Rt1: Into<$rt>, Rt2: Into<$rt>, Base: Into<RegOrSp64>>
+        impl<Rt1: IntoReg<$rt>, Rt2: IntoReg<$rt>, Base: IntoReg<RegOrSp64>>
             $trait_name<Rt1, Rt2, (Inc<$offset_type>, Base)>
             for $name<$rt, (Inc<$offset_type>, RegOrSp64)>
         {
             type Output = Self;
             fn new(rt: (Rt1, Rt2), (inc, base): (Inc<$offset_type>, Base)) -> Self {
                 Self {
-                    rt: (rt.0.into(), rt.1.into()),
-                    addr: (inc, base.into()),
+                    rt: (rt.0.into_reg(), rt.1.into_reg()),
+                    addr: (inc, base.into_reg()),
                 }
             }
         }
-        impl<Rt1: Into<$rt>, Rt2: Into<$rt>, Base: Into<RegOrSp64>>
+        impl<Rt1: IntoReg<$rt>, Rt2: IntoReg<$rt>, Base: IntoReg<RegOrSp64>>
             $trait_name<Rt1, Rt2, (Base, Inc<$offset_type>)>
             for $name<$rt, (RegOrSp64, Inc<$offset_type>)>
         {
             type Output = Self;
             fn new(rt: (Rt1, Rt2), (base, inc): (Base, Inc<$offset_type>)) -> Self {
                 Self {
-                    rt: (rt.0.into(), rt.1.into()),
-                    addr: (base.into(), inc),
+                    rt: (rt.0.into_reg(), rt.1.into_reg()),
+                    addr: (base.into_reg(), inc),
                 }
             }
         }
@@ -612,7 +612,7 @@ macro_rules! define_pair_fallible_rules {
         where
             $name<RtOut, ($crate::register::RegOrSp64, Ext)>:
                 $trait_name<RtInp1, RtInp2, (BaseInp, Ext)>,
-            $crate::register::RegOrSp64: From<BaseInp>,
+            BaseInp: IntoReg<$crate::register::RegOrSp64>,
         {
             type Output = ::core::result::Result<
                 <Self as $trait_name<RtInp1, RtInp2, (BaseInp, Ext)>>::Output,
@@ -637,7 +637,7 @@ macro_rules! define_pair_fallible_rules {
         where
             $name<RtOut, (Ext, $crate::register::RegOrSp64)>:
                 $trait_name<RtInp1, RtInp2, (Ext, BaseInp)>,
-            $crate::register::RegOrSp64: From<BaseInp>,
+            BaseInp: IntoReg<$crate::register::RegOrSp64>,
         {
             type Output = ::core::result::Result<
                 <Self as $trait_name<RtInp1, RtInp2, (Ext, BaseInp)>>::Output,

--- a/harm/src/instructions/ldst/shift_extend.rs
+++ b/harm/src/instructions/ldst/shift_extend.rs
@@ -43,12 +43,6 @@ pub enum LdStExtendOption32 {
     SXTW = 0b110,
 }
 
-impl Sealed for Reg64 {}
-impl Sealed for RegOrZero64 {}
-impl Sealed for Reg32 {}
-impl Sealed for RegOrZero32 {}
-
-// TODO sealed traits
 pub trait LdStDestShiftOption: Sealed {
     const SHIFT_SIZE: u32;
 }

--- a/harm/src/instructions/ldst/stp.rs
+++ b/harm/src/instructions/ldst/stp.rs
@@ -18,7 +18,7 @@ use aarchmrs_instructions::A64::ldst::{
 use super::{Inc, LdpStpOffset32, LdpStpOffset64};
 use crate::{
     bits::BitError,
-    register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64},
+    register::{RegOrSp64, RegOrZero32, RegOrZero64, Register},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/ldst/stp.rs
+++ b/harm/src/instructions/ldst/stp.rs
@@ -18,7 +18,7 @@ use aarchmrs_instructions::A64::ldst::{
 use super::{Inc, LdpStpOffset32, LdpStpOffset64};
 use crate::{
     bits::BitError,
-    register::{RegOrSp64, RegOrZero32, RegOrZero64, Register},
+    register::{IntoReg, RegOrSp64, RegOrZero32, RegOrZero64, Register},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/ldst/str.rs
+++ b/harm/src/instructions/ldst/str.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{ldr, ext, LdStExtendOption32, LdStShift};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! ldr(W1, X2);        // LDR W1, [X2]
@@ -61,8 +61,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{ldr, inc, preinc, postinc, LdStIncOffset};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! ldr(W1, (inc(offset), X2));       // preincrement, LDR W1, [X2, #4]!
 //! ldr(W1, (X2, inc(offset)));       // postincrement, LDR W1, [X2], #4
@@ -123,7 +123,7 @@ use super::{Inc, LdStIncOffset, ScaledOffset32, ScaledOffset64};
 use crate::{
     bits::BitError,
     instructions::RawInstruction,
-    register::{RegOrSp64, RegOrZero32, RegOrZero64, Register},
+    register::{IntoReg, RegOrSp64, RegOrZero32, RegOrZero64, Register},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/ldst/str.rs
+++ b/harm/src/instructions/ldst/str.rs
@@ -123,7 +123,7 @@ use super::{Inc, LdStIncOffset, ScaledOffset32, ScaledOffset64};
 use crate::{
     bits::BitError,
     instructions::RawInstruction,
-    register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64},
+    register::{RegOrSp64, RegOrZero32, RegOrZero64, Register},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/ldst/str.rs
+++ b/harm/src/instructions/ldst/str.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{ldr, ext, LdStExtendOption32, LdStShift};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! ldr(W1, X2);        // LDR W1, [X2]
@@ -61,8 +61,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{ldr, inc, preinc, postinc, LdStIncOffset};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! ldr(W1, (inc(offset), X2));       // preincrement, LDR W1, [X2, #4]!
 //! ldr(W1, (X2, inc(offset)));       // postincrement, LDR W1, [X2], #4

--- a/harm/src/instructions/ldst/strb.rs
+++ b/harm/src/instructions/ldst/strb.rs
@@ -78,7 +78,7 @@ use super::{ByteShift, Inc, LdStIncOffset, ScaledOffset8};
 use crate::{
     bits::BitError,
     instructions::RawInstruction,
-    register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64},
+    register::{RegOrSp64, RegOrZero32, RegOrZero64, Register},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/ldst/strb.rs
+++ b/harm/src/instructions/ldst/strb.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{strb, ext, LdStExtendOption32, LdStShift};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! strb(W1, X2);        // STRB W1, [X2]
@@ -53,8 +53,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{strb, inc, preinc, postinc, LdStIncOffset};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! strb(W1, (inc(offset), X2));       // preincrement, STRB W1, [X2, #4]!
 //! strb(W1, (X2, inc(offset)));       // postincrement, STRB W1, [X2], #4
@@ -78,7 +78,7 @@ use super::{ByteShift, Inc, LdStIncOffset, ScaledOffset8};
 use crate::{
     bits::BitError,
     instructions::RawInstruction,
-    register::{RegOrSp64, RegOrZero32, RegOrZero64, Register},
+    register::{IntoReg, RegOrSp64, RegOrZero32, RegOrZero64, Register},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/ldst/strb.rs
+++ b/harm/src/instructions/ldst/strb.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{strb, ext, LdStExtendOption32, LdStShift};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! strb(W1, X2);        // STRB W1, [X2]
@@ -53,8 +53,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{strb, inc, preinc, postinc, LdStIncOffset};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! strb(W1, (inc(offset), X2));       // preincrement, STRB W1, [X2, #4]!
 //! strb(W1, (X2, inc(offset)));       // postincrement, STRB W1, [X2], #4

--- a/harm/src/instructions/ldst/strh.rs
+++ b/harm/src/instructions/ldst/strh.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{strh, ext, LdStExtendOption32, LdStShift};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! strh(W1, X2);        // STRH W1, [X2]
@@ -55,8 +55,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{strh, inc, preinc, postinc, LdStIncOffset};
-//! use harm_types::A64::register::Reg32::*;
-//! use harm_types::A64::register::Reg64::*;
+//! use harm::register::Reg32::*;
+//! use harm::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! strh(W1, (inc(offset), X2));       // preincrement, STRH W1, [X2, #4]!
 //! strh(W1, (X2, inc(offset)));       // postincrement, STRH W1, [X2], #4

--- a/harm/src/instructions/ldst/strh.rs
+++ b/harm/src/instructions/ldst/strh.rs
@@ -19,8 +19,8 @@
 //! # Examples:
 //! ```
 //! # use harm::instructions::ldst::{strh, ext, LdStExtendOption32, LdStShift};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! use LdStExtendOption32::*;
 //!
 //! strh(W1, X2);        // STRH W1, [X2]
@@ -55,8 +55,8 @@
 //! Pre-increment and post-increment variants have the following syntax:
 //! ```
 //! # use harm::instructions::ldst::{strh, inc, preinc, postinc, LdStIncOffset};
-//! use harm::register::Reg32::*;
-//! use harm::register::Reg64::*;
+//! use harm_types::A64::register::Reg32::*;
+//! use harm_types::A64::register::Reg64::*;
 //! let offset = LdStIncOffset::new(4).unwrap();
 //! strh(W1, (inc(offset), X2));       // preincrement, STRH W1, [X2, #4]!
 //! strh(W1, (X2, inc(offset)));       // postincrement, STRH W1, [X2], #4
@@ -80,7 +80,7 @@ use super::{Inc, LdStIncOffset, ScaledOffset16};
 use crate::{
     bits::BitError,
     instructions::RawInstruction,
-    register::{RegOrSp64, RegOrZero32, RegOrZero64, Register},
+    register::{IntoReg, RegOrSp64, RegOrZero32, RegOrZero64, Register},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/ldst/strh.rs
+++ b/harm/src/instructions/ldst/strh.rs
@@ -80,7 +80,7 @@ use super::{Inc, LdStIncOffset, ScaledOffset16};
 use crate::{
     bits::BitError,
     instructions::RawInstruction,
-    register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64},
+    register::{RegOrSp64, RegOrZero32, RegOrZero64, Register},
     sealed::Sealed,
 };
 

--- a/harm/src/instructions/ldst/stur.rs
+++ b/harm/src/instructions/ldst/stur.rs
@@ -9,7 +9,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::{
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{RegOrSp64, RegOrZero32, RegOrZero64, Register};
+use crate::register::{IntoReg, RegOrSp64, RegOrZero32, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/instructions/ldst/stur.rs
+++ b/harm/src/instructions/ldst/stur.rs
@@ -9,7 +9,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::{
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{IntoCode, RegOrSp64, RegOrZero32, RegOrZero64};
+use crate::register::{RegOrSp64, RegOrZero32, RegOrZero64, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/instructions/ldst/sturb.rs
+++ b/harm/src/instructions/ldst/sturb.rs
@@ -7,7 +7,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::STURB_32_ldst_unscaled::STU
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{IntoCode, RegOrSp64, RegOrZero32};
+use crate::register::{RegOrSp64, RegOrZero32, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/instructions/ldst/sturb.rs
+++ b/harm/src/instructions/ldst/sturb.rs
@@ -7,7 +7,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::STURB_32_ldst_unscaled::STU
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{RegOrSp64, RegOrZero32, Register};
+use crate::register::{IntoReg, RegOrSp64, RegOrZero32, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/instructions/ldst/sturh.rs
+++ b/harm/src/instructions/ldst/sturh.rs
@@ -7,7 +7,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::STURH_32_ldst_unscaled::STU
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{RegOrSp64, RegOrZero32, Register};
+use crate::register::{IntoReg, RegOrSp64, RegOrZero32, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/instructions/ldst/sturh.rs
+++ b/harm/src/instructions/ldst/sturh.rs
@@ -7,7 +7,7 @@ use aarchmrs_instructions::A64::ldst::ldst_unscaled::STURH_32_ldst_unscaled::STU
 
 use crate::bits::BitError;
 use crate::instructions::RawInstruction;
-use crate::register::{IntoCode, RegOrSp64, RegOrZero32};
+use crate::register::{RegOrSp64, RegOrZero32, Register};
 use crate::sealed::Sealed;
 
 use super::UnscaledOffset;

--- a/harm/src/register.rs
+++ b/harm/src/register.rs
@@ -396,6 +396,66 @@ impl Register for RegOrZero32 {
     }
 }
 
+pub trait IntoReg<X>: Sealed {
+    fn into_reg(self) -> X;
+}
+
+impl IntoReg<RegOrSp64> for Reg64 {
+    #[inline]
+    fn into_reg(self) -> RegOrSp64 {
+        RegOrSp64::Reg(self)
+    }
+}
+
+impl IntoReg<RegOrSp64> for RegOrSp64 {
+    #[inline]
+    fn into_reg(self) -> RegOrSp64 {
+        self
+    }
+}
+
+impl IntoReg<RegOrZero64> for Reg64 {
+    #[inline]
+    fn into_reg(self) -> RegOrZero64 {
+        RegOrZero64::Reg(self)
+    }
+}
+
+impl IntoReg<RegOrZero64> for RegOrZero64 {
+    #[inline]
+    fn into_reg(self) -> RegOrZero64 {
+        self
+    }
+}
+
+impl IntoReg<RegOrSp32> for Reg32 {
+    #[inline]
+    fn into_reg(self) -> RegOrSp32 {
+        RegOrSp32::Reg(self)
+    }
+}
+
+impl IntoReg<RegOrSp32> for RegOrSp32 {
+    #[inline]
+    fn into_reg(self) -> RegOrSp32 {
+        self
+    }
+}
+
+impl IntoReg<RegOrZero32> for Reg32 {
+    #[inline]
+    fn into_reg(self) -> RegOrZero32 {
+        RegOrZero32::Reg(self)
+    }
+}
+
+impl IntoReg<RegOrZero32> for RegOrZero32 {
+    #[inline]
+    fn into_reg(self) -> RegOrZero32 {
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/harm/src/register.rs
+++ b/harm/src/register.rs
@@ -10,7 +10,9 @@ const NICHE_REG: u8 = 31;
 use aarchmrs_types::BitValue;
 use num_enum::TryFromPrimitive;
 
-pub trait Register {
+use crate::sealed::Sealed;
+
+pub trait Register: Sealed {
     fn code(&self) -> BitValue<5>;
 }
 
@@ -332,6 +334,13 @@ impl TryFrom<u8> for RegOrZero32 {
         })
     }
 }
+
+impl Sealed for Reg64 {}
+impl Sealed for RegOrSp64 {}
+impl Sealed for RegOrZero64 {}
+impl Sealed for Reg32 {}
+impl Sealed for RegOrSp32 {}
+impl Sealed for RegOrZero32 {}
 
 impl Register for Reg64 {
     #[inline]

--- a/harm/src/register.rs
+++ b/harm/src/register.rs
@@ -10,7 +10,7 @@ const NICHE_REG: u8 = 31;
 use aarchmrs_types::BitValue;
 use num_enum::TryFromPrimitive;
 
-pub trait IntoCode {
+pub trait Register {
     fn code(&self) -> BitValue<5>;
 }
 
@@ -333,21 +333,21 @@ impl TryFrom<u8> for RegOrZero32 {
     }
 }
 
-impl IntoCode for Reg64 {
+impl Register for Reg64 {
     #[inline]
     fn code(&self) -> BitValue<5> {
         BitValue::new_u32(*self as u32)
     }
 }
 
-impl IntoCode for Reg32 {
+impl Register for Reg32 {
     #[inline]
     fn code(&self) -> BitValue<5> {
         BitValue::new_u32(*self as u32)
     }
 }
 
-impl IntoCode for RegOrSp64 {
+impl Register for RegOrSp64 {
     #[inline]
     fn code(&self) -> BitValue<5> {
         BitValue::new_u32(match self {
@@ -357,7 +357,7 @@ impl IntoCode for RegOrSp64 {
     }
 }
 
-impl IntoCode for RegOrZero64 {
+impl Register for RegOrZero64 {
     #[inline]
     fn code(&self) -> BitValue<5> {
         BitValue::new_u32(match self {
@@ -367,7 +367,7 @@ impl IntoCode for RegOrZero64 {
     }
 }
 
-impl IntoCode for RegOrSp32 {
+impl Register for RegOrSp32 {
     #[inline]
     fn code(&self) -> BitValue<5> {
         BitValue::new_u32(match self {
@@ -377,7 +377,7 @@ impl IntoCode for RegOrSp32 {
     }
 }
 
-impl IntoCode for RegOrZero32 {
+impl Register for RegOrZero32 {
     #[inline]
     fn code(&self) -> BitValue<5> {
         BitValue::new_u32(match self {


### PR DESCRIPTION
It makes it more flexible (allowing to seal the trait and to split crates) and explicit (avoiding semantically overloaded `Into`).